### PR TITLE
Add MainMemory

### DIFF
--- a/slothpu/__init__.py
+++ b/slothpu/__init__.py
@@ -1,6 +1,7 @@
 # Import all the bits & pieces
 
 from ._slothpu import SlothPU
+from ._main_memory import MainMemory
 from ._memory import Memory
 from ._backplane import BackPlane
 from ._bus import Bus

--- a/slothpu/_backplane.py
+++ b/slothpu/_backplane.py
@@ -34,10 +34,9 @@ class BackPlane:
     @SALU_flag.setter
     def SALU_flag(self, value: int):
         assert isinstance(value, int)
-        assert value==0 or value==1
+        assert value == 0 or value == 1
         self._salu_flag = value
 
-    
     @property
     def DALU_flag(self) -> int:
         assert self._dalu_flag == 0 or self._dalu_flag == 1
@@ -46,5 +45,5 @@ class BackPlane:
     @DALU_flag.setter
     def DALU_flag(self, value: int):
         assert isinstance(value, int)
-        assert value==0 or value==1
+        assert value == 0 or value == 1
         self._dalu_flag = value

--- a/slothpu/_backplane.py
+++ b/slothpu/_backplane.py
@@ -7,6 +7,8 @@ class BackPlane:
         self._A_bus = Bus(self.n_bits)
         self._B_bus = Bus(self.n_bits)
         self._W_bus = Bus(self.n_bits)
+        self._salu_flag = 0
+        self._dalu_flag = 0
 
     @property
     def n_bits(self) -> int:
@@ -23,3 +25,26 @@ class BackPlane:
     @property
     def W_bus(self) -> Bus:
         return self._W_bus
+
+    @property
+    def SALU_flag(self) -> int:
+        assert self._salu_flag == 0 or self._salu_flag == 1
+        return self._salu_flag
+
+    @SALU_flag.setter
+    def SALU_flag(self, value: int):
+        assert isinstance(value, int)
+        assert value==0 or value==1
+        self._salu_flag = value
+
+    
+    @property
+    def DALU_flag(self) -> int:
+        assert self._dalu_flag == 0 or self._dalu_flag == 1
+        return self._dalu_flag
+
+    @DALU_flag.setter
+    def DALU_flag(self, value: int):
+        assert isinstance(value, int)
+        assert value==0 or value==1
+        self._dalu_flag = value

--- a/slothpu/_main_memory.py
+++ b/slothpu/_main_memory.py
@@ -1,0 +1,27 @@
+from turtle import back
+import bitarray.util
+
+from ._backplane import BackPlane
+from ._memory import Memory
+
+
+class MainMemory:
+    def __init__(self, n_locations: int, n_bits: int, backplane: BackPlane):
+        assert backplane is not None
+        assert isinstance(backplane, BackPlane)
+        self._backplane = backplane
+        self._memory = Memory(n_locations=n_locations, n_bits=n_bits)
+
+    @property
+    def memory(self) -> Memory:
+        return self._memory
+
+    def execute(self, command: str):
+        address = bitarray.util.ba2int(self._backplane.A_bus.value)
+
+        if command == "READ":
+            self._backplane.W_bus.value = self._memory[address]
+        elif command == "WRITE":
+            self._memory[address] = self._backplane.B_bus.value
+        else:
+            raise ValueError("Unrecognised memory command: " + command)

--- a/slothpu/_slothpu.py
+++ b/slothpu/_slothpu.py
@@ -27,7 +27,9 @@ class SlothPU:
         self._input_registers = Memory(8, n_bits_per_byte)
         self._output_registers = Memory(8, n_bits_per_byte)
         self._backplane = BackPlane(n_bits_per_byte)
-        self._main_memory = MainMemory(2**n_bits_per_byte, n_bits_per_byte, self.backplane)
+        self._main_memory = MainMemory(
+            2**n_bits_per_byte, n_bits_per_byte, self.backplane
+        )
 
     @property
     def pipeline_stage(self) -> str:

--- a/slothpu/_slothpu.py
+++ b/slothpu/_slothpu.py
@@ -1,6 +1,7 @@
 import bitarray
 import bitarray.util
 
+from ._main_memory import MainMemory
 from ._memory import Memory
 from ._backplane import BackPlane
 
@@ -26,7 +27,7 @@ class SlothPU:
         self._input_registers = Memory(8, n_bits_per_byte)
         self._output_registers = Memory(8, n_bits_per_byte)
         self._backplane = BackPlane(n_bits_per_byte)
-        self._memory = Memory(2**n_bits_per_byte, n_bits_per_byte)
+        self._main_memory = MainMemory(2**n_bits_per_byte, n_bits_per_byte, self.backplane)
 
     @property
     def pipeline_stage(self) -> str:
@@ -53,5 +54,5 @@ class SlothPU:
         return self._backplane
 
     @property
-    def memory(self) -> Memory:
-        return self._memory
+    def main_memory(self) -> MainMemory:
+        return self._main_memory

--- a/slothpu/interface/_backplane_widget.py
+++ b/slothpu/interface/_backplane_widget.py
@@ -3,6 +3,7 @@ import urwid
 from slothpu import BackPlane
 
 from ._bus_widget import BusWidget
+from ._flag_widget import FlagWidget
 
 
 class BackPlaneWidget(urwid.WidgetWrap):
@@ -15,10 +16,14 @@ class BackPlaneWidget(urwid.WidgetWrap):
             BusWidget(self._backplane.W_bus, "W"),
         ]
 
-        bus_pile = urwid.Pile(self._bus_widgets)
+        self._salu_widget = FlagWidget("SALU Flag", self._backplane.SALU_flag)
+        self._dalu_widget = FlagWidget("DALU Flag", self._backplane.DALU_flag)
+
+        bp_pile = urwid.Pile(self._bus_widgets)
+        flag_pile = urwid.Pile([self._salu_widget, self._dalu_widget])
 
         bp_box = urwid.LineBox(
-            urwid.Padding(bus_pile, align=urwid.CENTER),
+            urwid.Columns([bp_pile, flag_pile], dividechars=4),
             title="BackPlane",
             title_align=urwid.LEFT,
         )
@@ -28,3 +33,5 @@ class BackPlaneWidget(urwid.WidgetWrap):
     def update(self):
         for bw in self._bus_widgets:
             bw.update()
+        self._salu_widget.update(self._backplane.SALU_flag)
+        self._dalu_widget.update(self._backplane.DALU_flag)

--- a/slothpu/interface/_flag_widget.py
+++ b/slothpu/interface/_flag_widget.py
@@ -1,0 +1,16 @@
+import urwid
+
+
+class FlagWidget(urwid.WidgetWrap):
+    def __init__(self, name: str, value: int):
+        self._name = name
+
+        self._txt = urwid.Text(self.get_string(value))
+
+        super(FlagWidget, self).__init__(self._txt)
+
+    def get_string(self, value: str) -> str:
+        return f"{self._name} : {value}"
+
+    def update(self, value: int):
+        self._txt.set_text(self.get_string(value))

--- a/slothpu/interface/_flag_widget.py
+++ b/slothpu/interface/_flag_widget.py
@@ -9,7 +9,7 @@ class FlagWidget(urwid.WidgetWrap):
 
         super(FlagWidget, self).__init__(self._txt)
 
-    def get_string(self, value: str) -> str:
+    def get_string(self, value: int) -> str:
         return f"{self._name} : {value}"
 
     def update(self, value: int):

--- a/slothpu/interface/_memory_column.py
+++ b/slothpu/interface/_memory_column.py
@@ -1,17 +1,17 @@
 import urwid
 
-from slothpu import Memory
+from slothpu import MainMemory
 
 
 class MemoryColumn(urwid.ListBox):
-    def __init__(self, memory_area: Memory):
+    def __init__(self, main_memory: MainMemory):
         self.head = urwid.Text("Main Memory")
 
-        self._memory = memory_area
+        self._main_memory = main_memory
 
         self._memory_items = [
             urwid.Text(self.get_string_for_location(i))
-            for i in range(len(self._memory))
+            for i in range(len(self._main_memory.memory))
         ]
 
         slw = urwid.SimpleListWalker(self._memory_items)
@@ -19,7 +19,7 @@ class MemoryColumn(urwid.ListBox):
         super(MemoryColumn, self).__init__(slw)
 
     def get_string_for_location(self, i):
-        return f"{i:3} : {self._memory.get_as_string(i)}"
+        return f"{i:3} : {self._main_memory.memory.get_as_string(i)}"
 
     def update(self):
         for i in range(len(self._memory)):

--- a/slothpu/interface/_memory_column.py
+++ b/slothpu/interface/_memory_column.py
@@ -22,5 +22,5 @@ class MemoryColumn(urwid.ListBox):
         return f"{i:3} : {self._main_memory.memory.get_as_string(i)}"
 
     def update(self):
-        for i in range(len(self._memory)):
+        for i in range(len(self._main_memory.memory)):
             self._memory_items[i].set_text(self.get_string_for_location(i))

--- a/slothpu/interface/_memory_column.py
+++ b/slothpu/interface/_memory_column.py
@@ -18,7 +18,7 @@ class MemoryColumn(urwid.ListBox):
 
         super(MemoryColumn, self).__init__(slw)
 
-    def get_string_for_location(self, i):
+    def get_string_for_location(self, i: int):
         return f"{i:3} : {self._main_memory.memory.get_as_string(i)}"
 
     def update(self):

--- a/slothpu/interface/_slothpu_interface.py
+++ b/slothpu/interface/_slothpu_interface.py
@@ -49,7 +49,7 @@ class SlothPU_Interface:
         self._target = SlothPU()
 
         register_column = RegisterColumn(self._target)
-        memory_column = MemoryColumn(self._target.memory)
+        memory_column = MemoryColumn(self._target.main_memory)
         backplane = BackPlaneWidget(self._target.backplane)
         stage_bar = PipelineStageWidget(self)
 

--- a/test/test_backplane.py
+++ b/test/test_backplane.py
@@ -11,6 +11,7 @@ def test_smoke():
     assert target.SALU_flag == 0
     assert target.DALU_flag == 0
 
+
 def test_set_salu_flag():
     target = BackPlane(8)
     assert target.SALU_flag == 0

--- a/test/test_backplane.py
+++ b/test/test_backplane.py
@@ -8,3 +8,18 @@ def test_smoke():
     assert target.A_bus.n_bits == num_bits
     assert target.B_bus.n_bits == num_bits
     assert target.W_bus.n_bits == num_bits
+    assert target.SALU_flag == 0
+    assert target.DALU_flag == 0
+
+def test_set_salu_flag():
+    target = BackPlane(8)
+    assert target.SALU_flag == 0
+    target.SALU_flag = 1
+    assert target.SALU_flag == 1
+
+
+def test_set_dalu_flag():
+    target = BackPlane(8)
+    assert target.DALU_flag == 0
+    target.DALU_flag = 1
+    assert target.DALU_flag == 1

--- a/test/test_main_memory.py
+++ b/test/test_main_memory.py
@@ -2,6 +2,7 @@ import bitarray.util
 
 from slothpu import BackPlane, MainMemory
 
+
 def test_smoke():
     n_bits = 8
     bp = BackPlane(n_bits)
@@ -9,19 +10,19 @@ def test_smoke():
     target = MainMemory(2**n_bits, n_bits, bp)
 
     target_loc = 127
-    tl_ba = bitarray.util.int2ba(target_loc, endian='little')
-    tl_ba.fill() # Since n_bits=8
+    tl_ba = bitarray.util.int2ba(target_loc, endian="little")
+    tl_ba.fill()  # Since n_bits=8
     bp.A_bus.value = tl_ba
-    assert bp.W_bus.value == bitarray.util.zeros(8, endian='little')
+    assert bp.W_bus.value == bitarray.util.zeros(8, endian="little")
     target.execute("READ")
     # Memory values are initialised to their location
     assert bitarray.util.ba2int(bp.W_bus.value) == target_loc
 
     # Now write
-    write_value = 21 # Big enough to use 8 bits
-    bp.B_bus.value = bitarray.util.int2ba(write_value, length=n_bits,endian='little')
+    write_value = 21  # Big enough to use 8 bits
+    bp.B_bus.value = bitarray.util.int2ba(write_value, length=n_bits, endian="little")
     target.execute("WRITE")
     # Read it back
-    assert bitarray.util.ba2int(bp.W_bus.value) == target_loc # Should be unchanged
+    assert bitarray.util.ba2int(bp.W_bus.value) == target_loc  # Should be unchanged
     target.execute("READ")
     assert bitarray.util.ba2int(bp.W_bus.value) == write_value

--- a/test/test_main_memory.py
+++ b/test/test_main_memory.py
@@ -1,0 +1,27 @@
+import bitarray.util
+
+from slothpu import BackPlane, MainMemory
+
+def test_smoke():
+    n_bits = 8
+    bp = BackPlane(n_bits)
+
+    target = MainMemory(2**n_bits, n_bits, bp)
+
+    target_loc = 127
+    tl_ba = bitarray.util.int2ba(target_loc, endian='little')
+    tl_ba.fill() # Since n_bits=8
+    bp.A_bus.value = tl_ba
+    assert bp.W_bus.value == bitarray.util.zeros(8, endian='little')
+    target.execute("READ")
+    # Memory values are initialised to their location
+    assert bitarray.util.ba2int(bp.W_bus.value) == target_loc
+
+    # Now write
+    write_value = 21 # Big enough to use 8 bits
+    bp.B_bus.value = bitarray.util.int2ba(write_value, length=n_bits,endian='little')
+    target.execute("WRITE")
+    # Read it back
+    assert bitarray.util.ba2int(bp.W_bus.value) == target_loc # Should be unchanged
+    target.execute("READ")
+    assert bitarray.util.ba2int(bp.W_bus.value) == write_value


### PR DESCRIPTION
Add a `MainMemory` class which is connected to the `BackPlane`. Inputs and outputs are handled via the backplane, as shown in the test. Add in ALU flags to the `BackPlane` as well.