### PR TITLE
Bus rename and address expansion

### DIFF
--- a/slothpu/_backplane.py
+++ b/slothpu/_backplane.py
@@ -6,7 +6,7 @@ class BackPlane:
         self._n_bits = n_bits
         self._A_bus = Bus(self.n_bits)
         self._B_bus = Bus(self.n_bits)
-        self._W_bus = Bus(self.n_bits)
+        self._C_bus = Bus(self.n_bits)
         self._salu_flag = 0
         self._dalu_flag = 0
 
@@ -23,27 +23,5 @@ class BackPlane:
         return self._B_bus
 
     @property
-    def W_bus(self) -> Bus:
-        return self._W_bus
-
-    @property
-    def SALU_flag(self) -> int:
-        assert self._salu_flag == 0 or self._salu_flag == 1
-        return self._salu_flag
-
-    @SALU_flag.setter
-    def SALU_flag(self, value: int):
-        assert isinstance(value, int)
-        assert value == 0 or value == 1
-        self._salu_flag = value
-
-    @property
-    def DALU_flag(self) -> int:
-        assert self._dalu_flag == 0 or self._dalu_flag == 1
-        return self._dalu_flag
-
-    @DALU_flag.setter
-    def DALU_flag(self, value: int):
-        assert isinstance(value, int)
-        assert value == 0 or value == 1
-        self._dalu_flag = value
+    def C_bus(self) -> Bus:
+        return self._C_bus

--- a/slothpu/_main_memory.py
+++ b/slothpu/_main_memory.py
@@ -12,7 +12,10 @@ class MainMemory:
         assert backplane is not None
         assert isinstance(backplane, BackPlane)
         self._backplane = backplane
-        self._memory = Memory(n_locations=2**MainMemory.main_memory_address_bits, n_bits=self._backplane.n_bits)
+        self._memory = Memory(
+            n_locations=2**MainMemory.main_memory_address_bits,
+            n_bits=self._backplane.n_bits,
+        )
 
     @property
     def memory(self) -> Memory:

--- a/slothpu/_main_memory.py
+++ b/slothpu/_main_memory.py
@@ -6,22 +6,26 @@ from ._memory import Memory
 
 
 class MainMemory:
-    def __init__(self, n_locations: int, backplane: BackPlane):
+    main_memory_address_bits = 14
+
+    def __init__(self, backplane: BackPlane):
         assert backplane is not None
         assert isinstance(backplane, BackPlane)
         self._backplane = backplane
-        self._memory = Memory(n_locations=n_locations, n_bits=self._backplane.n_bits)
+        self._memory = Memory(n_locations=2**MainMemory.main_memory_address_bits, n_bits=self._backplane.n_bits)
 
     @property
     def memory(self) -> Memory:
         return self._memory
 
     def execute(self, command: str):
-        address = bitarray.util.ba2int(self._backplane.A_bus.value)
+        # Concatenate A and B buses for the address
+        ba_address = self._backplane.A_bus.value + self._backplane.B_bus.value
+        address = bitarray.util.ba2int(ba_address)
 
         if command == "READ":
-            self._backplane.W_bus.value = self._memory[address]
+            self._backplane.C_bus.value = self._memory[address]
         elif command == "WRITE":
-            self._memory[address] = self._backplane.B_bus.value
+            self._memory[address] = self._backplane.C_bus.value
         else:
             raise ValueError("Unrecognised memory command: " + command)

--- a/slothpu/_memory.py
+++ b/slothpu/_memory.py
@@ -16,7 +16,7 @@ class Memory:
             for _ in range(n_locations)
         ]
         for i in range(n_locations):
-            self[i] = bitarray.util.int2ba(i, endian="little")
+            self[i] = bitarray.util.int2ba(i % 2**self.n_bits, endian="little")
 
     @property
     def n_bits(self) -> int:

--- a/slothpu/_program_counter.py
+++ b/slothpu/_program_counter.py
@@ -8,28 +8,33 @@ from ._utils import bitarray_add, to_01_bigendian
 class ProgramCounter:
     def __init__(self, backplane: BackPlane):
         self._backplane = backplane
-        self._pc = bitarray.util.zeros(self._backplane.n_bits, endian="little")
+        self._n_bits = 2 * self._backplane.n_bits
+        self._pc = bitarray.util.zeros(self.n_bits, endian="little")
 
     @property
     def pc(self) -> bitarray.bitarray:
-        assert len(self._pc) == self._backplane.n_bits
+        assert len(self._pc) == self.n_bits
         assert self._pc.endian() == "little"
         assert self._pc[0] == 0, "PC must be even"
         return self._pc
+
+    @property
+    def n_bits(self) -> int:
+        return self._n_bits
 
     def get_as_string(self) -> str:
         return to_01_bigendian(self.pc)
 
     def _set_pc(self, value: bitarray.bitarray):
         assert isinstance(value, bitarray.bitarray)
-        assert len(value) == self._backplane.n_bits
+        assert len(value) == self.n_bits
         assert value.endian() == "little"
         assert value[0] == 0, "Must set PC to be even"
         # Make sure we copy
         self._pc = bitarray.bitarray(value)
 
     def increment(self):
-        step = bitarray.util.int2ba(2, length=self._backplane.n_bits, endian="little")
+        step = bitarray.util.int2ba(2, length=self.n_bits, endian="little")
         self._pc, _ = bitarray_add(self.pc, step, carry_in=0)
 
     def execute(self, command: str):
@@ -37,25 +42,30 @@ class ProgramCounter:
             self.increment()
         elif command == "BRANCH":
             # Copy....
-            self._set_pc(bitarray.bitarray(self._backplane.A_bus.value))
+            target = self._backplane.A_bus.value + self._backplane.B_bus.value
+            self._set_pc(target)
         elif command == "BRANCH_IF_ZERO":
-            if bitarray.util.ba2int(self._backplane.B_bus.value) == 0:
-                self._set_pc(bitarray.bitarray(self._backplane.A_bus.value))
+            target = self._backplane.A_bus.value + self._backplane.B_bus.value
+            if bitarray.util.ba2int(self._backplane.C_bus.value) == 0:
+                self._set_pc(target)
             else:
                 self.increment()
         elif command == "BRANCH_IF_NONZERO":
-            if bitarray.util.ba2int(self._backplane.B_bus.value) == 0:
+            target = self._backplane.A_bus.value + self._backplane.B_bus.value
+            if bitarray.util.ba2int(self._backplane.C_bus.value) == 0:
                 self.increment()
             else:
-                self._set_pc(bitarray.bitarray(self._backplane.A_bus.value))
+                self._set_pc(target)
         elif command == "FETCH0":
-            # Put current address onto A_bus
-            self._backplane.A_bus.value = self._pc
+            # Put current address onto A_bus and B_bus
+            self._backplane.A_bus.value = self._pc[0:8]
+            self._backplane.B_bus.value = self._pc[8:16]
         elif command == "FETCH1":
-            # Put current address+1 onto A_bus
+            # Put current address+1 onto A_bus and B_bus
             one = bitarray.util.int2ba(
                 1, length=self._backplane.n_bits, endian="little"
             )
-            self._backplane.A_bus.value = self._pc | one
+            self._backplane.A_bus.value = self._pc[0:8] | one
+            self._backplane.B_bus.value = self._pc[8:16]
         else:
             raise ValueError("Unrecognised PC command: " + command)

--- a/slothpu/_slothpu.py
+++ b/slothpu/_slothpu.py
@@ -28,7 +28,7 @@ class SlothPU:
         self._input_registers = Memory(8, n_bits_per_byte)
         self._output_registers = Memory(8, n_bits_per_byte)
         self._backplane = BackPlane(n_bits_per_byte)
-        self._main_memory = MainMemory(2**n_bits_per_byte, self.backplane)
+        self._main_memory = MainMemory(self.backplane)
         self._program_counter = ProgramCounter(self._backplane)
 
     @property

--- a/slothpu/interface/_backplane_widget.py
+++ b/slothpu/interface/_backplane_widget.py
@@ -13,17 +13,12 @@ class BackPlaneWidget(urwid.WidgetWrap):
         self._bus_widgets = [
             BusWidget(self._backplane.A_bus, "A"),
             BusWidget(self._backplane.B_bus, "B"),
-            BusWidget(self._backplane.W_bus, "W"),
+            BusWidget(self._backplane.C_bus, "C"),
         ]
-
-        self._salu_widget = FlagWidget("SALU Flag", self._backplane.SALU_flag)
-        self._dalu_widget = FlagWidget("DALU Flag", self._backplane.DALU_flag)
-
         bp_pile = urwid.Pile(self._bus_widgets)
-        flag_pile = urwid.Pile([self._salu_widget, self._dalu_widget])
 
         bp_box = urwid.LineBox(
-            urwid.Columns([bp_pile, flag_pile], dividechars=4),
+            bp_pile,
             title="BackPlane",
             title_align=urwid.LEFT,
         )
@@ -33,5 +28,3 @@ class BackPlaneWidget(urwid.WidgetWrap):
     def update(self):
         for bw in self._bus_widgets:
             bw.update()
-        self._salu_widget.update(self._backplane.SALU_flag)
-        self._dalu_widget.update(self._backplane.DALU_flag)

--- a/slothpu/interface/_memory_column.py
+++ b/slothpu/interface/_memory_column.py
@@ -19,7 +19,7 @@ class MemoryColumn(urwid.ListBox):
         super(MemoryColumn, self).__init__(slw)
 
     def get_string_for_location(self, i: int):
-        return f"{i:3} : {self._main_memory.memory.get_as_string(i)}"
+        return f"{i:6} : {self._main_memory.memory.get_as_string(i)}"
 
     def update(self):
         for i in range(len(self._main_memory.memory)):

--- a/test/test_backplane.py
+++ b/test/test_backplane.py
@@ -8,5 +8,3 @@ def test_smoke():
     assert target.A_bus.n_bits == num_bits
     assert target.B_bus.n_bits == num_bits
     assert target.C_bus.n_bits == num_bits
-
-

--- a/test/test_backplane.py
+++ b/test/test_backplane.py
@@ -7,20 +7,6 @@ def test_smoke():
 
     assert target.A_bus.n_bits == num_bits
     assert target.B_bus.n_bits == num_bits
-    assert target.W_bus.n_bits == num_bits
-    assert target.SALU_flag == 0
-    assert target.DALU_flag == 0
+    assert target.C_bus.n_bits == num_bits
 
 
-def test_set_salu_flag():
-    target = BackPlane(8)
-    assert target.SALU_flag == 0
-    target.SALU_flag = 1
-    assert target.SALU_flag == 1
-
-
-def test_set_dalu_flag():
-    target = BackPlane(8)
-    assert target.DALU_flag == 0
-    target.DALU_flag = 1
-    assert target.DALU_flag == 1

--- a/test/test_main_memory.py
+++ b/test/test_main_memory.py
@@ -7,22 +7,23 @@ def test_smoke():
     n_bits = 8
     bp = BackPlane(n_bits)
 
-    target = MainMemory(2**n_bits, bp)
+    target = MainMemory(bp)
 
-    target_loc = 127
-    tl_ba = bitarray.util.int2ba(target_loc, endian="little")
-    tl_ba.fill()  # Since n_bits=8
-    bp.A_bus.value = tl_ba
-    assert bp.W_bus.value == bitarray.util.zeros(8, endian="little")
+    target_loc = 4000
+    assert target_loc < 2**14 # Only have 14 bits of address lines
+    tl_ba = bitarray.util.int2ba(target_loc, 16, endian="little")
+    bp.A_bus.value = tl_ba[0:8]
+    bp.B_bus.value = tl_ba[8:16]
+    assert bp.C_bus.value == bitarray.util.zeros(8, endian="little")
     target.execute("READ")
     # Memory values are initialised to their location
-    assert bitarray.util.ba2int(bp.W_bus.value) == target_loc
+    assert bitarray.util.ba2int(bp.C_bus.value) == target_loc %  2**n_bits
 
     # Now write
     write_value = 21
-    bp.B_bus.value = bitarray.util.int2ba(write_value, length=n_bits, endian="little")
+    bp.C_bus.value = bitarray.util.int2ba(write_value, length=n_bits, endian="little")
     target.execute("WRITE")
     # Read it back
-    assert bitarray.util.ba2int(bp.W_bus.value) == target_loc  # Should be unchanged
+    bp.C_bus.value = bitarray.util.zeros(8, endian='little')
     target.execute("READ")
-    assert bitarray.util.ba2int(bp.W_bus.value) == write_value
+    assert bitarray.util.ba2int(bp.C_bus.value) == write_value

--- a/test/test_main_memory.py
+++ b/test/test_main_memory.py
@@ -10,20 +10,20 @@ def test_smoke():
     target = MainMemory(bp)
 
     target_loc = 4000
-    assert target_loc < 2**14 # Only have 14 bits of address lines
+    assert target_loc < 2**14  # Only have 14 bits of address lines
     tl_ba = bitarray.util.int2ba(target_loc, 16, endian="little")
     bp.A_bus.value = tl_ba[0:8]
     bp.B_bus.value = tl_ba[8:16]
     assert bp.C_bus.value == bitarray.util.zeros(8, endian="little")
     target.execute("READ")
     # Memory values are initialised to their location
-    assert bitarray.util.ba2int(bp.C_bus.value) == target_loc %  2**n_bits
+    assert bitarray.util.ba2int(bp.C_bus.value) == target_loc % 2**n_bits
 
     # Now write
     write_value = 21
     bp.C_bus.value = bitarray.util.int2ba(write_value, length=n_bits, endian="little")
     target.execute("WRITE")
     # Read it back
-    bp.C_bus.value = bitarray.util.zeros(8, endian='little')
+    bp.C_bus.value = bitarray.util.zeros(8, endian="little")
     target.execute("READ")
     assert bitarray.util.ba2int(bp.C_bus.value) == write_value

--- a/test/test_program_counter.py
+++ b/test/test_program_counter.py
@@ -35,7 +35,7 @@ def test_execute_fetch0():
 
     # Want to poke a value which will affect the upper and lower byte
     start_loc = 8200
-    loc_ba = bitarray.util.int2ba(start_loc, target.n_bits, endian='little')
+    loc_ba = bitarray.util.int2ba(start_loc, target.n_bits, endian="little")
     bp.A_bus.value = loc_ba[0:8]
     bp.B_bus.value = loc_ba[8:16]
     target.execute("BRANCH")
@@ -43,7 +43,7 @@ def test_execute_fetch0():
     assert bitarray.util.ba2int(target.pc) == start_loc
 
     # Clear the buses
-    bp.A_bus.value = bitarray.util.zeros(8, endian='little')
+    bp.A_bus.value = bitarray.util.zeros(8, endian="little")
     bp.B_bus.value = bitarray.util.zeros(8, endian="little")
     target.execute("FETCH0")
     expect_b, expect_a = divmod(start_loc, 2**bp.n_bits)
@@ -57,17 +57,17 @@ def test_execute_fetch1():
 
     # Want to poke a value which will affect the upper and lower byte
     start_loc = 9200
-    loc_ba = bitarray.util.int2ba(start_loc, target.n_bits, endian='little')
+    loc_ba = bitarray.util.int2ba(start_loc, target.n_bits, endian="little")
     bp.A_bus.value = loc_ba[0:8]
     bp.B_bus.value = loc_ba[8:16]
     target.execute("BRANCH")
 
     assert bitarray.util.ba2int(target.pc) == start_loc
 
-    bp.A_bus.value = bitarray.util.zeros(8, endian='little')
+    bp.A_bus.value = bitarray.util.zeros(8, endian="little")
     bp.B_bus.value = bitarray.util.zeros(8, endian="little")
     target.execute("FETCH1")
-    expect_b, expect_a = divmod(start_loc+1, 2**bp.n_bits)
+    expect_b, expect_a = divmod(start_loc + 1, 2**bp.n_bits)
     assert bitarray.util.ba2int(bp.A_bus.value) == expect_a
     assert bitarray.util.ba2int(bp.B_bus.value) == expect_b
 
@@ -80,7 +80,7 @@ def test_execute_branch():
     target.increment()
     assert bitarray.util.ba2int(target.pc) == 4
     loc = 4000
-    loc_ba = bitarray.util.int2ba(loc, target.n_bits, endian='little')
+    loc_ba = bitarray.util.int2ba(loc, target.n_bits, endian="little")
     bp.A_bus.value = loc_ba[0:8]
     bp.B_bus.value = loc_ba[8:16]
     target.execute("BRANCH")
@@ -95,14 +95,14 @@ def test_execute_branch_if_zero():
     jump_loc = 5684
 
     # Push the inital PC value
-    loc_ba = bitarray.util.int2ba(start_loc, target.n_bits, endian='little')
+    loc_ba = bitarray.util.int2ba(start_loc, target.n_bits, endian="little")
     bp.A_bus.value = loc_ba[0:8]
     bp.B_bus.value = loc_ba[8:16]
     target.execute("BRANCH")
     assert bitarray.util.ba2int(target.pc) == start_loc
 
     # Now set up A & B with the branch target
-    loc_ba = bitarray.util.int2ba(jump_loc, target.n_bits, endian='little')
+    loc_ba = bitarray.util.int2ba(jump_loc, target.n_bits, endian="little")
     bp.A_bus.value = loc_ba[0:8]
     bp.B_bus.value = loc_ba[8:16]
 
@@ -111,7 +111,9 @@ def test_execute_branch_if_zero():
 
     # Check that we increment instead of branching
     target.execute("BRANCH_IF_ZERO")
-    assert bitarray.util.ba2int(target.pc) == start_loc+2  # We will have incremented instead
+    assert (
+        bitarray.util.ba2int(target.pc) == start_loc + 2
+    )  # We will have incremented instead
 
     # Now have C_bus be zero, see that we branch
     bp.C_bus.value = bitarray.util.zeros(8, endian="little")
@@ -127,14 +129,14 @@ def test_execute_branch_if_nonzero():
     jump_loc = 5684
 
     # Push the inital PC value
-    loc_ba = bitarray.util.int2ba(start_loc, target.n_bits, endian='little')
+    loc_ba = bitarray.util.int2ba(start_loc, target.n_bits, endian="little")
     bp.A_bus.value = loc_ba[0:8]
     bp.B_bus.value = loc_ba[8:16]
     target.execute("BRANCH")
     assert bitarray.util.ba2int(target.pc) == start_loc
 
     # Now set up A & B with the branch target
-    loc_ba = bitarray.util.int2ba(jump_loc, target.n_bits, endian='little')
+    loc_ba = bitarray.util.int2ba(jump_loc, target.n_bits, endian="little")
     bp.A_bus.value = loc_ba[0:8]
     bp.B_bus.value = loc_ba[8:16]
 

--- a/test/test_program_counter.py
+++ b/test/test_program_counter.py
@@ -33,24 +33,43 @@ def test_execute_fetch0():
     bp = BackPlane(8)
     target = ProgramCounter(bp)
 
-    target.increment()
-    target.increment()
-    assert bitarray.util.ba2int(target.pc) == 4
-    assert bitarray.util.ba2int(bp.A_bus.value) == 0
+    # Want to poke a value which will affect the upper and lower byte
+    start_loc = 8200
+    loc_ba = bitarray.util.int2ba(start_loc, target.n_bits, endian='little')
+    bp.A_bus.value = loc_ba[0:8]
+    bp.B_bus.value = loc_ba[8:16]
+    target.execute("BRANCH")
+
+    assert bitarray.util.ba2int(target.pc) == start_loc
+
+    # Clear the buses
+    bp.A_bus.value = bitarray.util.zeros(8, endian='little')
+    bp.B_bus.value = bitarray.util.zeros(8, endian="little")
     target.execute("FETCH0")
-    assert bitarray.util.ba2int(bp.A_bus.value) == 4
+    expect_b, expect_a = divmod(start_loc, 2**bp.n_bits)
+    assert bitarray.util.ba2int(bp.A_bus.value) == expect_a
+    assert bitarray.util.ba2int(bp.B_bus.value) == expect_b
 
 
 def test_execute_fetch1():
     bp = BackPlane(8)
     target = ProgramCounter(bp)
 
-    target.increment()
-    target.increment()
-    assert bitarray.util.ba2int(target.pc) == 4
-    assert bitarray.util.ba2int(bp.A_bus.value) == 0
+    # Want to poke a value which will affect the upper and lower byte
+    start_loc = 9200
+    loc_ba = bitarray.util.int2ba(start_loc, target.n_bits, endian='little')
+    bp.A_bus.value = loc_ba[0:8]
+    bp.B_bus.value = loc_ba[8:16]
+    target.execute("BRANCH")
+
+    assert bitarray.util.ba2int(target.pc) == start_loc
+
+    bp.A_bus.value = bitarray.util.zeros(8, endian='little')
+    bp.B_bus.value = bitarray.util.zeros(8, endian="little")
     target.execute("FETCH1")
-    assert bitarray.util.ba2int(bp.A_bus.value) == 5
+    expect_b, expect_a = divmod(start_loc+1, 2**bp.n_bits)
+    assert bitarray.util.ba2int(bp.A_bus.value) == expect_a
+    assert bitarray.util.ba2int(bp.B_bus.value) == expect_b
 
 
 def test_execute_branch():
@@ -60,8 +79,10 @@ def test_execute_branch():
     target.increment()
     target.increment()
     assert bitarray.util.ba2int(target.pc) == 4
-    loc = 10
-    bp.A_bus.value = bitarray.util.int2ba(loc, length=bp.n_bits, endian="little")
+    loc = 4000
+    loc_ba = bitarray.util.int2ba(loc, target.n_bits, endian='little')
+    bp.A_bus.value = loc_ba[0:8]
+    bp.B_bus.value = loc_ba[8:16]
     target.execute("BRANCH")
     assert bitarray.util.ba2int(target.pc) == loc
 
@@ -70,39 +91,59 @@ def test_execute_branch_if_zero():
     bp = BackPlane(8)
     target = ProgramCounter(bp)
 
-    target.increment()
-    target.increment()
-    assert bitarray.util.ba2int(target.pc) == 4
-    loc = 130
-    bp.A_bus.value = bitarray.util.int2ba(loc, length=bp.n_bits, endian="little")
+    start_loc = 3512
+    jump_loc = 5684
 
-    # Set up B_bus to be non-zero
-    bp.B_bus.value = bitarray.util.int2ba(2, length=bp.n_bits, endian="little")
+    # Push the inital PC value
+    loc_ba = bitarray.util.int2ba(start_loc, target.n_bits, endian='little')
+    bp.A_bus.value = loc_ba[0:8]
+    bp.B_bus.value = loc_ba[8:16]
+    target.execute("BRANCH")
+    assert bitarray.util.ba2int(target.pc) == start_loc
+
+    # Now set up A & B with the branch target
+    loc_ba = bitarray.util.int2ba(jump_loc, target.n_bits, endian='little')
+    bp.A_bus.value = loc_ba[0:8]
+    bp.B_bus.value = loc_ba[8:16]
+
+    # Set up C bus to be non_zero
+    bp.C_bus.value = bitarray.util.int2ba(2, length=bp.n_bits, endian="little")
+
+    # Check that we increment instead of branching
     target.execute("BRANCH_IF_ZERO")
-    assert bitarray.util.ba2int(target.pc) == 6  # We will have incremented instead
+    assert bitarray.util.ba2int(target.pc) == start_loc+2  # We will have incremented instead
 
-    # Now have B_bus be zero
-    bp.B_bus.value = bitarray.util.zeros(8, endian="little")
+    # Now have C_bus be zero, see that we branch
+    bp.C_bus.value = bitarray.util.zeros(8, endian="little")
     target.execute("BRANCH_IF_ZERO")
-    assert bitarray.util.ba2int(target.pc) == loc
+    assert bitarray.util.ba2int(target.pc) == jump_loc
 
 
-def test_execute_branch_if_zero():
+def test_execute_branch_if_nonzero():
     bp = BackPlane(8)
     target = ProgramCounter(bp)
 
-    target.increment()
-    target.increment()
-    assert bitarray.util.ba2int(target.pc) == 4
-    loc = 130
-    bp.A_bus.value = bitarray.util.int2ba(loc, length=bp.n_bits, endian="little")
+    start_loc = 3512
+    jump_loc = 5684
 
-    # Set up B_bus to be non-zero
-    bp.B_bus.value = bitarray.util.int2ba(2, length=bp.n_bits, endian="little")
-    target.execute("BRANCH_IF_NONZERO")
-    assert bitarray.util.ba2int(target.pc) == loc
+    # Push the inital PC value
+    loc_ba = bitarray.util.int2ba(start_loc, target.n_bits, endian='little')
+    bp.A_bus.value = loc_ba[0:8]
+    bp.B_bus.value = loc_ba[8:16]
+    target.execute("BRANCH")
+    assert bitarray.util.ba2int(target.pc) == start_loc
 
-    # Now have B_bus be zero
-    bp.B_bus.value = bitarray.util.zeros(8, endian="little")
+    # Now set up A & B with the branch target
+    loc_ba = bitarray.util.int2ba(jump_loc, target.n_bits, endian='little')
+    bp.A_bus.value = loc_ba[0:8]
+    bp.B_bus.value = loc_ba[8:16]
+
+    # Check that we increment instead of branching
+    bp.C_bus.value = bitarray.util.zeros(8, endian="little")
     target.execute("BRANCH_IF_NONZERO")
-    assert bitarray.util.ba2int(target.pc) == loc + 2  # Increment instead
+    assert bitarray.util.ba2int(target.pc) == start_loc + 2
+
+    # Check that we branch
+    bp.C_bus.value = bitarray.util.int2ba(2, length=bp.n_bits, endian="little")
+    target.execute("BRANCH_IF_NONZERO")
+    assert bitarray.util.ba2int(target.pc) == jump_loc


### PR DESCRIPTION
Rename `W_bus` to `C_bus` because we're expanding to 16-bit memory addressing (although the main memory will only have 14 bits of addresses). Whenever we generate addresses, these are make by concatenating `A_bus` and `B_bus` (with `A_bus` being the lower bits).