### PR TITLE
Add 'enable increment' to PC

### DIFF
--- a/emulator/slothpu/_program_counter.py
+++ b/emulator/slothpu/_program_counter.py
@@ -39,13 +39,13 @@ class ProgramCounter:
         self._pc = bitarray.bitarray(value)
 
     def increment(self):
-        if self.increment_enable:
-            step = bitarray.util.int2ba(2, length=self.n_bits, endian="little")
-            self._pc, _ = bitarray_add(self.pc, step, carry_in=0)
+        step = bitarray.util.int2ba(2, length=self.n_bits, endian="little")
+        self._pc, _ = bitarray_add(self.pc, step, carry_in=0)
 
     def execute(self, command: str):
         if command == "INC":
-            self.increment()
+            if self.increment_enable:
+                self.increment()
         elif command == "BRANCH":
             # Copy....
             target = self._backplane.A_bus.value + self._backplane.B_bus.value

--- a/emulator/slothpu/_program_counter.py
+++ b/emulator/slothpu/_program_counter.py
@@ -9,6 +9,7 @@ class ProgramCounter:
     def __init__(self, backplane: BackPlane):
         self._backplane = backplane
         self._n_bits = 2 * self._backplane.n_bits
+        self._increment_enable = True
         self._pc = bitarray.util.zeros(self.n_bits, endian="little")
 
     @property
@@ -22,6 +23,10 @@ class ProgramCounter:
     def n_bits(self) -> int:
         return self._n_bits
 
+    @property
+    def increment_enable(self) -> bool:
+        return self._increment_enable
+
     def get_as_string(self) -> str:
         return to_01_bigendian(self.pc)
 
@@ -34,8 +39,9 @@ class ProgramCounter:
         self._pc = bitarray.bitarray(value)
 
     def increment(self):
-        step = bitarray.util.int2ba(2, length=self.n_bits, endian="little")
-        self._pc, _ = bitarray_add(self.pc, step, carry_in=0)
+        if self.increment_enable:
+            step = bitarray.util.int2ba(2, length=self.n_bits, endian="little")
+            self._pc, _ = bitarray_add(self.pc, step, carry_in=0)
 
     def execute(self, command: str):
         if command == "INC":
@@ -44,16 +50,18 @@ class ProgramCounter:
             # Copy....
             target = self._backplane.A_bus.value + self._backplane.B_bus.value
             self._set_pc(target)
+            self._increment_enable = False
         elif command == "BRANCH_IF_ZERO":
             target = self._backplane.A_bus.value + self._backplane.B_bus.value
             if bitarray.util.ba2int(self._backplane.C_bus.value) == 0:
                 self._set_pc(target)
-            else:
-                self.increment()
+                self._increment_enable = False
         elif command == "FETCH0":
             # Put current address onto A_bus and B_bus
             self._backplane.A_bus.value = self._pc[0:8]
             self._backplane.B_bus.value = self._pc[8:16]
+            # Also ensure that increment is enabled
+            self._increment_enable = True
         elif command == "FETCH1":
             # Put current address+1 onto A_bus and B_bus
             one = bitarray.util.int2ba(

--- a/emulator/slothpu/interface/_program_counter_widget.py
+++ b/emulator/slothpu/interface/_program_counter_widget.py
@@ -7,13 +7,19 @@ class ProgramCounterWidget(urwid.WidgetWrap):
     def __init__(self, pc: ProgramCounter):
         self._pc = pc
 
-        self._pc_text = urwid.Text(self._pc.get_as_string())
+        self._pc_text = urwid.Text("")
+        self._inc_enable_text = urwid.Text("")
+
+        pc_pile = urwid.Pile([self._pc_text, self._inc_enable_text])
 
         pc_box = urwid.LineBox(
-            self._pc_text, title="Program Counter", title_align=urwid.LEFT
+            
+            pc_pile, title="Program Counter", title_align=urwid.LEFT
         )
+        self.update()
 
         super(ProgramCounterWidget, self).__init__(pc_box)
 
     def update(self):
         self._pc_text.set_text(self._pc.get_as_string())
+        self._inc_enable_text.set_text(f"Increment Enable: {self._pc.increment_enable}")

--- a/emulator/slothpu/interface/_program_counter_widget.py
+++ b/emulator/slothpu/interface/_program_counter_widget.py
@@ -12,10 +12,7 @@ class ProgramCounterWidget(urwid.WidgetWrap):
 
         pc_pile = urwid.Pile([self._pc_text, self._inc_enable_text])
 
-        pc_box = urwid.LineBox(
-            
-            pc_pile, title="Program Counter", title_align=urwid.LEFT
-        )
+        pc_box = urwid.LineBox(pc_pile, title="Program Counter", title_align=urwid.LEFT)
         self.update()
 
         super(ProgramCounterWidget, self).__init__(pc_box)

--- a/emulator/test/test_program_counter.py
+++ b/emulator/test/test_program_counter.py
@@ -27,6 +27,9 @@ def test_execute_increment():
     target.execute("INC")
     target.execute("INC")
     assert bitarray.util.ba2int(target.pc) == 4
+    target._increment_enable = False
+    target.execute("INC")
+    assert bitarray.util.ba2int(target.pc) == 4
 
 
 def test_execute_fetch0():
@@ -39,16 +42,20 @@ def test_execute_fetch0():
     bp.A_bus.value = loc_ba[0:8]
     bp.B_bus.value = loc_ba[8:16]
     target.execute("BRANCH")
+    assert target.increment_enable == False # Because we pushed a branch
 
     assert bitarray.util.ba2int(target.pc) == start_loc
 
     # Clear the buses
     bp.A_bus.value = bitarray.util.zeros(8, endian="little")
     bp.B_bus.value = bitarray.util.zeros(8, endian="little")
+
     target.execute("FETCH0")
     expect_b, expect_a = divmod(start_loc, 2**bp.n_bits)
     assert bitarray.util.ba2int(bp.A_bus.value) == expect_a
     assert bitarray.util.ba2int(bp.B_bus.value) == expect_b
+    # FETCH0 should re-enable increment
+    assert target.increment_enable == True
 
 
 def test_execute_fetch1():
@@ -61,6 +68,7 @@ def test_execute_fetch1():
     bp.A_bus.value = loc_ba[0:8]
     bp.B_bus.value = loc_ba[8:16]
     target.execute("BRANCH")
+    assert target.increment_enable == False
 
     assert bitarray.util.ba2int(target.pc) == start_loc
 
@@ -78,6 +86,7 @@ def test_execute_branch():
 
     target.increment()
     target.increment()
+    assert target.increment_enable == True
     assert bitarray.util.ba2int(target.pc) == 4
     loc = 4000
     loc_ba = bitarray.util.int2ba(loc, target.n_bits, endian="little")
@@ -85,6 +94,7 @@ def test_execute_branch():
     bp.B_bus.value = loc_ba[8:16]
     target.execute("BRANCH")
     assert bitarray.util.ba2int(target.pc) == loc
+    assert target.increment_enable == False
 
 
 def test_execute_branch_if_zero():
@@ -109,13 +119,16 @@ def test_execute_branch_if_zero():
     # Set up C bus to be non_zero
     bp.C_bus.value = bitarray.util.int2ba(2, length=bp.n_bits, endian="little")
 
-    # Check that we increment instead of branching
+    # Check that we do not branch and we leave incrementing enabled
+    target._increment_enable = True
     target.execute("BRANCH_IF_ZERO")
     assert (
-        bitarray.util.ba2int(target.pc) == start_loc + 2
-    )  # We will have incremented instead
+        bitarray.util.ba2int(target.pc) == start_loc
+    )
+    assert target.increment_enable == True
 
-    # Now have C_bus be zero, see that we branch
+    # Now have C_bus be zero, see that we branch and disable incrementing
     bp.C_bus.value = bitarray.util.zeros(8, endian="little")
     target.execute("BRANCH_IF_ZERO")
     assert bitarray.util.ba2int(target.pc) == jump_loc
+    assert target.increment_enable == False

--- a/emulator/test/test_program_counter.py
+++ b/emulator/test/test_program_counter.py
@@ -42,7 +42,7 @@ def test_execute_fetch0():
     bp.A_bus.value = loc_ba[0:8]
     bp.B_bus.value = loc_ba[8:16]
     target.execute("BRANCH")
-    assert target.increment_enable == False # Because we pushed a branch
+    assert target.increment_enable == False  # Because we pushed a branch
 
     assert bitarray.util.ba2int(target.pc) == start_loc
 
@@ -122,9 +122,7 @@ def test_execute_branch_if_zero():
     # Check that we do not branch and we leave incrementing enabled
     target._increment_enable = True
     target.execute("BRANCH_IF_ZERO")
-    assert (
-        bitarray.util.ba2int(target.pc) == start_loc
-    )
+    assert bitarray.util.ba2int(target.pc) == start_loc
     assert target.increment_enable == True
 
     # Now have C_bus be zero, see that we branch and disable incrementing


### PR DESCRIPTION
Change the `ProgramCounter` logic slightly, so that there is a flag which indicates when a command in increment should be performed. This is set to `True` by the FETCH0 pipeline stage, but is set to `False` if a branch occurs.