### PR TITLE
Split up `execute()`

### DIFF
--- a/emulator/slothpu/_instruction_register.py
+++ b/emulator/slothpu/_instruction_register.py
@@ -45,16 +45,16 @@ class InstructionRegister:
         # Given how it is read, little endian might be better
         return to_01_bigendian(self.ir)
 
-    def execute(self, command: str):
-        if command == "FETCH0":
-            self._ir[0:8] = self._bp.C_bus.value
-        elif command == "FETCH1":
-            self._ir[8:16] = self._bp.C_bus.value
-        elif command == "DECODE":
-            # NOT YET COMPLETE!
-            self._unit = bitarray.util.ba2int(self._ir[0:3])
-            self._R_A = bitarray.util.ba2int(self._ir[7:10])
-            self._R_B = bitarray.util.ba2int(self._ir[10:13])
-            self._R_C = bitarray.util.ba2int(self._ir[13:16])
-        else:
-            raise ValueError(f"Unrecognised IR command: {command}")
+    def fetch0(self):
+        self._ir[0:8] = self._bp.C_bus.value
+
+    def fetch1(self):
+        self._ir[8:16] = self._bp.C_bus.value
+
+    def decode(self):
+        # NOT YET COMPLETE!
+        self._unit = bitarray.util.ba2int(self._ir[0:3])
+        self._R_A = bitarray.util.ba2int(self._ir[7:10])
+        self._R_B = bitarray.util.ba2int(self._ir[10:13])
+        self._R_C = bitarray.util.ba2int(self._ir[13:16])
+

--- a/emulator/slothpu/_instruction_register.py
+++ b/emulator/slothpu/_instruction_register.py
@@ -57,4 +57,3 @@ class InstructionRegister:
         self._R_A = bitarray.util.ba2int(self._ir[7:10])
         self._R_B = bitarray.util.ba2int(self._ir[10:13])
         self._R_C = bitarray.util.ba2int(self._ir[13:16])
-

--- a/emulator/slothpu/_main_memory.py
+++ b/emulator/slothpu/_main_memory.py
@@ -20,6 +20,12 @@ class MainMemory:
     def memory(self) -> Memory:
         return self._memory
 
+    def fetch0(self):
+        self.execute("READ")
+
+    def fetch1(self):
+        self.execute("READ")
+
     def execute(self, command: str):
         # Concatenate A and B buses for the address
         ba_address = self._backplane.A_bus.value + self._backplane.B_bus.value

--- a/emulator/slothpu/_program_counter.py
+++ b/emulator/slothpu/_program_counter.py
@@ -51,9 +51,7 @@ class ProgramCounter:
 
     def fetch1(self):
         # Put current address+1 onto A_bus and B_bus
-        one = bitarray.util.int2ba(
-            1, length=self._backplane.n_bits, endian="little"
-        )
+        one = bitarray.util.int2ba(1, length=self._backplane.n_bits, endian="little")
         self._backplane.A_bus.value = self._pc[0:8] | one
         self._backplane.B_bus.value = self._pc[8:16]
 

--- a/emulator/slothpu/_slothpu.py
+++ b/emulator/slothpu/_slothpu.py
@@ -45,18 +45,18 @@ class SlothPU:
         if self._pipeline_stage == 0:
             # Fetch0
             # PARTIALLY COMPLETE
-            self.program_counter.execute("FETCH0")
-            self.main_memory.execute("READ")
-            self.instruction_register.execute("FETCH0")
+            self.program_counter.fetch0()
+            self.main_memory.fetch0()
+            self.instruction_register.fetch0()
         elif self._pipeline_stage == 1:
             # Fetch1
             # PARTIALLY COMPLETE
-            self.program_counter.execute("FETCH1")
-            self.main_memory.execute("READ")
-            self.instruction_register.execute("FETCH1")
+            self.program_counter.fetch1()
+            self.main_memory.fetch1()
+            self.instruction_register.fetch1()
         elif self._pipeline_stage == 2:
             # PARTIALLY COMPLETE
-            self.instruction_register.execute("DECODE")
+            self.instruction_register.decode()
 
             # B and C are more complex and TBD...
             self.register_file.A_register = self.instruction_register.R_A
@@ -73,7 +73,7 @@ class SlothPU:
         elif self._pipeline_stage == 5:
             # UpdatePC
             # JUST FOR NOW
-            self.program_counter.execute("INC")
+            self.program_counter.updatepc()
         else:
             raise ValueError(f"Can't do anything: {self._pipeline_stage}")
 

--- a/emulator/test/test_instruction_register.py
+++ b/emulator/test/test_instruction_register.py
@@ -19,7 +19,7 @@ def test_fetch0():
 
     value = 127
     bp.C_bus.value = bitarray.util.int2ba(value, bp.n_bits, endian="little")
-    target.execute("FETCH0")
+    target.fetch0()
     assert bitarray.util.ba2int(target.ir) == value
 
 
@@ -31,7 +31,7 @@ def test_fetch1():
 
     value = 119
     bp.C_bus.value = bitarray.util.int2ba(value, bp.n_bits, endian="little")
-    target.execute("FETCH1")
+    target.fetch1()
     assert bitarray.util.ba2int(target.ir) == value * 2**bp.n_bits
 
 
@@ -48,7 +48,7 @@ def test_decode():
     assert target.R_A == 0
     assert target.R_B == 0
     assert target.R_C == 0
-    target.execute("DECODE")
+    target.decode()
     assert target.unit == 2
     assert target.R_A == 5
     assert target.R_B == 3

--- a/emulator/test/test_program_counter.py
+++ b/emulator/test/test_program_counter.py
@@ -42,7 +42,7 @@ def test_fetch0():
     bp.A_bus.value = loc_ba[0:8]
     bp.B_bus.value = loc_ba[8:16]
     target.execute("BRANCH")
-    assert target.increment_enable is False # Because we pushed a branch
+    assert target.increment_enable is False  # Because we pushed a branch
 
     assert bitarray.util.ba2int(target.pc) == start_loc
 

--- a/emulator/test/test_program_counter.py
+++ b/emulator/test/test_program_counter.py
@@ -19,20 +19,20 @@ def test_increment():
     assert bitarray.util.ba2int(target.pc) == 2
 
 
-def test_execute_increment():
+def test_updatepc():
     bp = BackPlane(8)
     target = ProgramCounter(bp)
 
     assert bitarray.util.ba2int(target.pc) == 0
-    target.execute("INC")
-    target.execute("INC")
+    target.updatepc()
+    target.updatepc()
     assert bitarray.util.ba2int(target.pc) == 4
     target._increment_enable = False
-    target.execute("INC")
+    target.updatepc()
     assert bitarray.util.ba2int(target.pc) == 4
 
 
-def test_execute_fetch0():
+def test_fetch0():
     bp = BackPlane(8)
     target = ProgramCounter(bp)
 
@@ -42,7 +42,7 @@ def test_execute_fetch0():
     bp.A_bus.value = loc_ba[0:8]
     bp.B_bus.value = loc_ba[8:16]
     target.execute("BRANCH")
-    assert not target.increment_enable  # Because we pushed a branch
+    assert target.increment_enable is False # Because we pushed a branch
 
     assert bitarray.util.ba2int(target.pc) == start_loc
 
@@ -50,15 +50,15 @@ def test_execute_fetch0():
     bp.A_bus.value = bitarray.util.zeros(8, endian="little")
     bp.B_bus.value = bitarray.util.zeros(8, endian="little")
 
-    target.execute("FETCH0")
+    target.fetch0()
     expect_b, expect_a = divmod(start_loc, 2**bp.n_bits)
     assert bitarray.util.ba2int(bp.A_bus.value) == expect_a
     assert bitarray.util.ba2int(bp.B_bus.value) == expect_b
     # FETCH0 should re-enable increment
-    assert target.increment_enable
+    assert target.increment_enable is True
 
 
-def test_execute_fetch1():
+def test_fetch1():
     bp = BackPlane(8)
     target = ProgramCounter(bp)
 
@@ -68,13 +68,13 @@ def test_execute_fetch1():
     bp.A_bus.value = loc_ba[0:8]
     bp.B_bus.value = loc_ba[8:16]
     target.execute("BRANCH")
-    assert not target.increment_enable
+    assert target.increment_enable is not True
 
     assert bitarray.util.ba2int(target.pc) == start_loc
 
     bp.A_bus.value = bitarray.util.zeros(8, endian="little")
     bp.B_bus.value = bitarray.util.zeros(8, endian="little")
-    target.execute("FETCH1")
+    target.fetch1()
     expect_b, expect_a = divmod(start_loc + 1, 2**bp.n_bits)
     assert bitarray.util.ba2int(bp.A_bus.value) == expect_a
     assert bitarray.util.ba2int(bp.B_bus.value) == expect_b


### PR DESCRIPTION
Rather than have the `execute()` method called whenever a functional unit is supposed to do something, have a separate method for each pipeline stage. The `execute()` method will remain for those units which need it. Have not updated the `RegisterFile` yet, since larger changes are planned.