### PR TITLE
Add SALU

### DIFF
--- a/docs/functional_units.md
+++ b/docs/functional_units.md
@@ -124,35 +124,43 @@ Would just copy the value... unsure of the value of this.
 ### Barrel Shift Left (SALU LBARREL)
 
 Perform a barrel shift left on the value.
-That is 87654321 becomes 76543218.
+That is 87654321 becomes 76543218; we are interpreting this as
+a left shift on the implied integer, not a left shift on an
+array of bits.
 Set the flag to zero
 
 ### Barrel Shift Right (SALU RBARREL)
 
 Perform a barrel shift right on the value.
-That is 87654321 becomes 187654321.
+That is 87654321 becomes 18765432; we are interpreting this as
+a left shift on the implied integer, not a left shift on an
+array of bits.
 Set the flag to zero
 
 ### Shift Left Inject 0 (SALU LSHIFT0)
 
 Perform a left shift on the value, injecting 0.
 That is 87654321 becomes 76543210.
+We are interpreting the left shift as a multiply by two (mod 256).
 Set the flag to the value of bit 8.
 
 ### Shift Right Inject 0 (SALU RSHIFT0)
 
 Perform a right shift on the value, injecting 0.
 That is 87654321 becomes 08765432.
+We are interpreting the left shift as a divide by two on the integer.
 Set the flag to the value of bit 0.
 
 ### Shift Left Inject 1 (SALU LSHIFT1)
 
 Perform a left shift on the value, injecting 1.
+We are interpreting the left shift as a multiply by two (mod 256).
 Set the flag to the value of bit 8.
 
 ### Shift Right Inject 1 (SALU RSHIFT1)
 
 Perform a right shift on the value, injecting 1.
+We are interpreting the left shift as a divide by two on the integer.
 Set the flag to the value of bit 0.
 
 

--- a/emulator/slothpu/__init__.py
+++ b/emulator/slothpu/__init__.py
@@ -9,5 +9,6 @@ from ._memory import Memory  # noqa: F401
 from ._program_counter import ProgramCounter  # noqa: F401
 from ._register_file import RegisterFile  # noqa: F401
 from ._register_unit import RegisterUnit  # noqa: F401
+from ._salu import SALU  # noqa: F401
 from ._slothpu import SlothPU  # noqa: F401
 from ._status_register import StatusRegister  # noqa: F401

--- a/emulator/slothpu/_salu.py
+++ b/emulator/slothpu/_salu.py
@@ -26,5 +26,8 @@ class SALU:
             )
             self._bp.C_bus.value = result
             self._bp.SALU_flag = 1 - borrow
+        elif command == "NOT":
+            self._bp.C_bus.value = ~self._bp.A_bus.value
+            self._bp.SALU_flag = 0
         else:
             raise ValueError(f"SALU not recogised {command}")

--- a/emulator/slothpu/_salu.py
+++ b/emulator/slothpu/_salu.py
@@ -21,9 +21,7 @@ class SALU:
             self._bp.C_bus.value = result
             self._bp.SALU_flag = carry
         elif command == "DEC":
-            result, borrow = bitarray_add(
-                self._bp.A_bus.value, ~one, 1
-            )
+            result, borrow = bitarray_add(self._bp.A_bus.value, ~one, 1)
             self._bp.C_bus.value = result
             self._bp.SALU_flag = 1 - borrow
         elif command == "NOT":
@@ -38,7 +36,7 @@ class SALU:
             # in the array. So with a little-endian interpretation
             # a left shift will shift towards a[0], which
             # would be a _right_ shift on the integer
-            top_bit = self._bp.A_bus.value[self.n_bits-1]
+            top_bit = self._bp.A_bus.value[self.n_bits - 1]
             tmp = self._bp.A_bus.value >> 1
             assert len(tmp) == 8
             tmp[0] = top_bit
@@ -48,17 +46,17 @@ class SALU:
             # See not about bitarray shift operators above
             bottom_bit = self._bp.A_bus.value[0]
             tmp = self._bp.A_bus.value << 1
-            tmp[self.n_bits-1] = bottom_bit
+            tmp[self.n_bits - 1] = bottom_bit
             self._bp.C_bus.value = tmp
             self._bp.SALU_flag = 0
         elif command == "LSHIFT0":
             # See note about bitarray shift operators above
-            dropped_bit = self._bp.A_bus.value[self.n_bits-1]
+            dropped_bit = self._bp.A_bus.value[self.n_bits - 1]
             self._bp.C_bus.value = self._bp.A_bus.value >> 1
             self._bp.SALU_flag = dropped_bit
         elif command == "LSHIFT1":
             # See note about bitarray shift operators above
-            dropped_bit = self._bp.A_bus.value[self.n_bits-1]
+            dropped_bit = self._bp.A_bus.value[self.n_bits - 1]
             tmp = self._bp.A_bus.value >> 1
             tmp[0] = 1
             self._bp.C_bus.value = tmp
@@ -72,7 +70,7 @@ class SALU:
             # See note about bitarray shift operators above
             dropped_bit = self._bp.A_bus.value[0]
             tmp = self._bp.A_bus.value << 1
-            tmp[self.n_bits-1] = 1
+            tmp[self.n_bits - 1] = 1
             self._bp.C_bus.value = tmp
             self._bp.SALU_flag = dropped_bit
         else:

--- a/emulator/slothpu/_salu.py
+++ b/emulator/slothpu/_salu.py
@@ -29,5 +29,8 @@ class SALU:
         elif command == "NOT":
             self._bp.C_bus.value = ~self._bp.A_bus.value
             self._bp.SALU_flag = 0
+        elif command == "COPY":
+            self._bp.C_bus.value = self._bp.A_bus.value
+            self._bp.SALU_flag = 0
         else:
             raise ValueError(f"SALU not recogised {command}")

--- a/emulator/slothpu/_salu.py
+++ b/emulator/slothpu/_salu.py
@@ -33,15 +33,26 @@ class SALU:
             self._bp.C_bus.value = self._bp.A_bus.value
             self._bp.SALU_flag = 0
         elif command == "LBARREL":
+            # Slight complication: bitarray shift operators
+            # are performed relative to the first element
+            # in the array. So with a little-endian interpretation
+            # a left shift will shift towards a[0], which
+            # would be a _right_ shift on the integer
             top_bit = self._bp.A_bus.value[7]
-            tmp = self._bp.A_bus.value << 1
-            print(tmp)
+            tmp = self._bp.A_bus.value >> 1
             assert len(tmp) == 8
             tmp[0] = top_bit
             self._bp.C_bus.value = tmp
             self._bp.SALU_flag = 0
         elif command == "LSHIFT0":
-            self._bp.C_bus.value = self._bp.A_bus.value << 1
-            self._bp.SALU_flag = 0
+            dropped_bit = self._bp.A_bus.value[7]
+            self._bp.C_bus.value = self._bp.A_bus.value >> 1
+            self._bp.SALU_flag = dropped_bit
+        elif command == "LSHIFT1":
+            dropped_bit = self._bp.A_bus.value[7]
+            tmp = self._bp.A_bus.value >> 1
+            tmp[0] = 1
+            self._bp.C_bus.value = tmp
+            self._bp.SALU_flag = dropped_bit
         else:
             raise ValueError(f"SALU not recogised {command}")

--- a/emulator/slothpu/_salu.py
+++ b/emulator/slothpu/_salu.py
@@ -1,0 +1,30 @@
+import bitarray.util
+
+from ._backplane import BackPlane
+
+from ._utils import bitarray_add
+
+
+class SALU:
+    def __init__(self, backplane: BackPlane):
+        self._bp = backplane
+        self._n_bits = self._bp.n_bits
+
+    @property
+    def n_bits(self) -> int:
+        return self._n_bits
+
+    def execute(self, command: str):
+        one = bitarray.util.int2ba(1, self.n_bits, endian="little")
+        if command == "INC":
+            result, carry = bitarray_add(self._bp.A_bus.value, one, 0)
+            self._bp.C_bus.value = result
+            self._bp.SALU_flag = carry
+        elif command == "SUB":
+            result, borrow = bitarray_add(
+                self._bp.A_bus.value, ~one, 1
+            )
+            self._bp.C_bus.value = result
+            self._bp.SALU_flag = 1 - borrow
+        else:
+            raise ValueError(f"SALU not recogised {command}")

--- a/emulator/slothpu/_salu.py
+++ b/emulator/slothpu/_salu.py
@@ -32,5 +32,16 @@ class SALU:
         elif command == "COPY":
             self._bp.C_bus.value = self._bp.A_bus.value
             self._bp.SALU_flag = 0
+        elif command == "LBARREL":
+            top_bit = self._bp.A_bus.value[7]
+            tmp = self._bp.A_bus.value << 1
+            print(tmp)
+            assert len(tmp) == 8
+            tmp[0] = top_bit
+            self._bp.C_bus.value = tmp
+            self._bp.SALU_flag = 0
+        elif command == "LSHIFT0":
+            self._bp.C_bus.value = self._bp.A_bus.value << 1
+            self._bp.SALU_flag = 0
         else:
             raise ValueError(f"SALU not recogised {command}")

--- a/emulator/slothpu/_salu.py
+++ b/emulator/slothpu/_salu.py
@@ -20,7 +20,7 @@ class SALU:
             result, carry = bitarray_add(self._bp.A_bus.value, one, 0)
             self._bp.C_bus.value = result
             self._bp.SALU_flag = carry
-        elif command == "SUB":
+        elif command == "DEC":
             result, borrow = bitarray_add(
                 self._bp.A_bus.value, ~one, 1
             )

--- a/emulator/slothpu/_salu.py
+++ b/emulator/slothpu/_salu.py
@@ -38,20 +38,41 @@ class SALU:
             # in the array. So with a little-endian interpretation
             # a left shift will shift towards a[0], which
             # would be a _right_ shift on the integer
-            top_bit = self._bp.A_bus.value[7]
+            top_bit = self._bp.A_bus.value[self.n_bits-1]
             tmp = self._bp.A_bus.value >> 1
             assert len(tmp) == 8
             tmp[0] = top_bit
             self._bp.C_bus.value = tmp
             self._bp.SALU_flag = 0
+        elif command == "RBARREL":
+            # See not about bitarray shift operators above
+            bottom_bit = self._bp.A_bus.value[0]
+            tmp = self._bp.A_bus.value << 1
+            tmp[self.n_bits-1] = bottom_bit
+            self._bp.C_bus.value = tmp
+            self._bp.SALU_flag = 0
         elif command == "LSHIFT0":
-            dropped_bit = self._bp.A_bus.value[7]
+            # See note about bitarray shift operators above
+            dropped_bit = self._bp.A_bus.value[self.n_bits-1]
             self._bp.C_bus.value = self._bp.A_bus.value >> 1
             self._bp.SALU_flag = dropped_bit
         elif command == "LSHIFT1":
-            dropped_bit = self._bp.A_bus.value[7]
+            # See note about bitarray shift operators above
+            dropped_bit = self._bp.A_bus.value[self.n_bits-1]
             tmp = self._bp.A_bus.value >> 1
             tmp[0] = 1
+            self._bp.C_bus.value = tmp
+            self._bp.SALU_flag = dropped_bit
+        elif command == "RSHIFT0":
+            # See note about bitarray shift operators above
+            dropped_bit = self._bp.A_bus.value[0]
+            self._bp.C_bus.value = self._bp.A_bus.value << 1
+            self._bp.SALU_flag = dropped_bit
+        elif command == "RSHIFT1":
+            # See note about bitarray shift operators above
+            dropped_bit = self._bp.A_bus.value[0]
+            tmp = self._bp.A_bus.value << 1
+            tmp[self.n_bits-1] = 1
             self._bp.C_bus.value = tmp
             self._bp.SALU_flag = dropped_bit
         else:

--- a/emulator/slothpu/_slothpu.py
+++ b/emulator/slothpu/_slothpu.py
@@ -1,7 +1,9 @@
 from ._backplane import BackPlane
+from ._dalu import DALU
 from ._instruction_register import InstructionRegister
 from ._main_memory import MainMemory
 from ._program_counter import ProgramCounter
+from ._salu import SALU
 from ._status_register import StatusRegister
 from ._register_file import RegisterFile
 
@@ -29,6 +31,8 @@ class SlothPU:
         self._program_counter = ProgramCounter(self._backplane)
         self._instruction_register = InstructionRegister(self._backplane)
         self._status_register = StatusRegister(self._backplane)
+        self._salu = SALU(self.backplane)
+        self._dalu = DALU(self.backplane)
 
     @property
     def pipeline_stage(self) -> str:
@@ -100,3 +104,11 @@ class SlothPU:
     @property
     def status_register(self) -> StatusRegister:
         return self._status_register
+
+    @property
+    def salu(self) -> SALU:
+        return self._salu
+
+    @property
+    def dalu(self) -> DALU:
+        return self._dalu

--- a/emulator/test/test_salu.py
+++ b/emulator/test/test_salu.py
@@ -46,3 +46,19 @@ def test_dec(a: int):
     target.execute("DEC")
     assert bitarray.util.ba2int(bp.C_bus.value) == c
     assert bp.SALU_flag == borrow
+
+@pytest.mark.parametrize('a', a_vals)
+def test_not(a: int):
+    bp = BackPlane(8)
+    target = SALU(bp)
+    assert a < 256
+
+    bp.A_bus.value = bitarray.util.int2ba(a, 8, endian="little")
+    assert bitarray.util.ba2int(bp.C_bus.value) == 0
+    assert bp.SALU_flag == 0
+
+    c = 255 - a
+
+    target.execute("NOT")
+    assert bitarray.util.ba2int(bp.C_bus.value) == c
+    assert bp.SALU_flag == 0

--- a/emulator/test/test_salu.py
+++ b/emulator/test/test_salu.py
@@ -4,9 +4,10 @@ import pytest
 
 from slothpu import SALU, BackPlane
 
-a_vals = [0,1,2,4,7,15,87,126,127,128,129, 253, 254, 255]
+a_vals = [0, 1, 2, 4, 7, 15, 87, 126, 127, 128, 129, 253, 254, 255]
 
-@pytest.mark.parametrize('a', a_vals)
+
+@pytest.mark.parametrize("a", a_vals)
 def test_inc(a: int):
     bp = BackPlane(8)
     target = SALU(bp)
@@ -17,17 +18,17 @@ def test_inc(a: int):
     assert bp.SALU_flag == 0
 
     c = a + 1
-    carry=0
+    carry = 0
     if c == 256:
         c = 0
-        carry=1
+        carry = 1
 
     target.execute("INC")
     assert bitarray.util.ba2int(bp.C_bus.value) == c
     assert bp.SALU_flag == carry
 
 
-@pytest.mark.parametrize('a', a_vals)
+@pytest.mark.parametrize("a", a_vals)
 def test_dec(a: int):
     bp = BackPlane(8)
     target = SALU(bp)
@@ -38,16 +39,17 @@ def test_dec(a: int):
     assert bp.SALU_flag == 0
 
     c = a - 1
-    borrow=0
+    borrow = 0
     if c < 0:
         c = 255
-        borrow=1
+        borrow = 1
 
     target.execute("DEC")
     assert bitarray.util.ba2int(bp.C_bus.value) == c
     assert bp.SALU_flag == borrow
 
-@pytest.mark.parametrize('a', a_vals)
+
+@pytest.mark.parametrize("a", a_vals)
 def test_not(a: int):
     bp = BackPlane(8)
     target = SALU(bp)
@@ -63,7 +65,8 @@ def test_not(a: int):
     assert bitarray.util.ba2int(bp.C_bus.value) == c
     assert bp.SALU_flag == 0
 
-@pytest.mark.parametrize('a', a_vals)
+
+@pytest.mark.parametrize("a", a_vals)
 def test_copy(a: int):
     bp = BackPlane(8)
     target = SALU(bp)
@@ -79,7 +82,8 @@ def test_copy(a: int):
     assert bitarray.util.ba2int(bp.C_bus.value) == c
     assert bp.SALU_flag == 0
 
-@pytest.mark.parametrize('a', a_vals)
+
+@pytest.mark.parametrize("a", a_vals)
 def test_lbarrel(a: int):
     bp = BackPlane(8)
     target = SALU(bp)
@@ -98,7 +102,8 @@ def test_lbarrel(a: int):
     assert bitarray.util.ba2int(bp.C_bus.value) == c
     assert bp.SALU_flag == 0
 
-@pytest.mark.parametrize('a', a_vals)
+
+@pytest.mark.parametrize("a", a_vals)
 def test_rbarrel(a: int):
     bp = BackPlane(8)
     target = SALU(bp)
@@ -115,7 +120,8 @@ def test_rbarrel(a: int):
     assert bitarray.util.ba2int(bp.C_bus.value) == c
     assert bp.SALU_flag == 0
 
-@pytest.mark.parametrize('a', a_vals)
+
+@pytest.mark.parametrize("a", a_vals)
 def test_lshift0(a: int):
     bp = BackPlane(8)
     target = SALU(bp)
@@ -132,7 +138,8 @@ def test_lshift0(a: int):
     assert bitarray.util.ba2int(bp.C_bus.value) == c
     assert bp.SALU_flag == dropped_bit
 
-@pytest.mark.parametrize('a', a_vals)
+
+@pytest.mark.parametrize("a", a_vals)
 def test_lshift1(a: int):
     bp = BackPlane(8)
     target = SALU(bp)
@@ -144,13 +151,14 @@ def test_lshift1(a: int):
 
     c = a << 1
     dropped_bit, c = divmod(c, 256)
-    c = c+1 # Inject the 1
+    c = c + 1  # Inject the 1
 
     target.execute("LSHIFT1")
     assert bitarray.util.ba2int(bp.C_bus.value) == c
     assert bp.SALU_flag == dropped_bit
 
-@pytest.mark.parametrize('a', a_vals)
+
+@pytest.mark.parametrize("a", a_vals)
 def test_rshift0(a: int):
     bp = BackPlane(8)
     target = SALU(bp)
@@ -166,7 +174,8 @@ def test_rshift0(a: int):
     assert bitarray.util.ba2int(bp.C_bus.value) == c
     assert bp.SALU_flag == dropped_bit
 
-@pytest.mark.parametrize('a', a_vals)
+
+@pytest.mark.parametrize("a", a_vals)
 def test_rshift1(a: int):
     bp = BackPlane(8)
     target = SALU(bp)
@@ -177,7 +186,7 @@ def test_rshift1(a: int):
     assert bp.SALU_flag == 0
 
     c, dropped_bit = divmod(a, 2)
-    c = c + 128 # Inject the 1
+    c = c + 128  # Inject the 1
 
     target.execute("RSHIFT1")
     assert bitarray.util.ba2int(bp.C_bus.value) == c

--- a/emulator/test/test_salu.py
+++ b/emulator/test/test_salu.py
@@ -99,6 +99,23 @@ def test_lbarrel(a: int):
     assert bp.SALU_flag == 0
 
 @pytest.mark.parametrize('a', a_vals)
+def test_rbarrel(a: int):
+    bp = BackPlane(8)
+    target = SALU(bp)
+    assert a < 256
+
+    bp.A_bus.value = bitarray.util.int2ba(a, 8, endian="little")
+    assert bitarray.util.ba2int(bp.C_bus.value) == 0
+    assert bp.SALU_flag == 0
+
+    c, bottom_bit = divmod(a, 2)
+    c = c + (bottom_bit * 128)
+
+    target.execute("RBARREL")
+    assert bitarray.util.ba2int(bp.C_bus.value) == c
+    assert bp.SALU_flag == 0
+
+@pytest.mark.parametrize('a', a_vals)
 def test_lshift0(a: int):
     bp = BackPlane(8)
     target = SALU(bp)
@@ -130,5 +147,38 @@ def test_lshift1(a: int):
     c = c+1 # Inject the 1
 
     target.execute("LSHIFT1")
+    assert bitarray.util.ba2int(bp.C_bus.value) == c
+    assert bp.SALU_flag == dropped_bit
+
+@pytest.mark.parametrize('a', a_vals)
+def test_rshift0(a: int):
+    bp = BackPlane(8)
+    target = SALU(bp)
+    assert a < 256
+
+    bp.A_bus.value = bitarray.util.int2ba(a, 8, endian="little")
+    assert bitarray.util.ba2int(bp.C_bus.value) == 0
+    assert bp.SALU_flag == 0
+
+    c, dropped_bit = divmod(a, 2)
+
+    target.execute("RSHIFT0")
+    assert bitarray.util.ba2int(bp.C_bus.value) == c
+    assert bp.SALU_flag == dropped_bit
+
+@pytest.mark.parametrize('a', a_vals)
+def test_rshift1(a: int):
+    bp = BackPlane(8)
+    target = SALU(bp)
+    assert a < 256
+
+    bp.A_bus.value = bitarray.util.int2ba(a, 8, endian="little")
+    assert bitarray.util.ba2int(bp.C_bus.value) == 0
+    assert bp.SALU_flag == 0
+
+    c, dropped_bit = divmod(a, 2)
+    c = c + 128 # Inject the 1
+
+    target.execute("RSHIFT1")
     assert bitarray.util.ba2int(bp.C_bus.value) == c
     assert bp.SALU_flag == dropped_bit

--- a/emulator/test/test_salu.py
+++ b/emulator/test/test_salu.py
@@ -62,3 +62,19 @@ def test_not(a: int):
     target.execute("NOT")
     assert bitarray.util.ba2int(bp.C_bus.value) == c
     assert bp.SALU_flag == 0
+
+@pytest.mark.parametrize('a', a_vals)
+def test_copy(a: int):
+    bp = BackPlane(8)
+    target = SALU(bp)
+    assert a < 256
+
+    bp.A_bus.value = bitarray.util.int2ba(a, 8, endian="little")
+    assert bitarray.util.ba2int(bp.C_bus.value) == 0
+    assert bp.SALU_flag == 0
+
+    c = a
+
+    target.execute("COPY")
+    assert bitarray.util.ba2int(bp.C_bus.value) == c
+    assert bp.SALU_flag == 0

--- a/emulator/test/test_salu.py
+++ b/emulator/test/test_salu.py
@@ -1,0 +1,48 @@
+import bitarray.util
+
+import pytest
+
+from slothpu import SALU, BackPlane
+
+a_vals = [0,1,2,4,7,15,87,126,127,128,129, 253, 254, 255]
+
+@pytest.mark.parametrize('a', a_vals)
+def test_inc(a: int):
+    bp = BackPlane(8)
+    target = SALU(bp)
+    assert a < 256
+
+    bp.A_bus.value = bitarray.util.int2ba(a, 8, endian="little")
+    assert bitarray.util.ba2int(bp.C_bus.value) == 0
+    assert bp.SALU_flag == 0
+
+    c = a + 1
+    carry=0
+    if c == 256:
+        c = 0
+        carry=1
+
+    target.execute("INC")
+    assert bitarray.util.ba2int(bp.C_bus.value) == c
+    assert bp.SALU_flag == carry
+
+
+@pytest.mark.parametrize('a', a_vals)
+def test_dec(a: int):
+    bp = BackPlane(8)
+    target = SALU(bp)
+    assert a < 256
+
+    bp.A_bus.value = bitarray.util.int2ba(a, 8, endian="little")
+    assert bitarray.util.ba2int(bp.C_bus.value) == 0
+    assert bp.SALU_flag == 0
+
+    c = a - 1
+    borrow=0
+    if c < 0:
+        c = 255
+        borrow=1
+
+    target.execute("DEC")
+    assert bitarray.util.ba2int(bp.C_bus.value) == c
+    assert bp.SALU_flag == borrow

--- a/emulator/test/test_salu.py
+++ b/emulator/test/test_salu.py
@@ -78,3 +78,40 @@ def test_copy(a: int):
     target.execute("COPY")
     assert bitarray.util.ba2int(bp.C_bus.value) == c
     assert bp.SALU_flag == 0
+
+@pytest.mark.parametrize('a', a_vals)
+def test_lbarrel(a: int):
+    bp = BackPlane(8)
+    target = SALU(bp)
+    assert a < 256
+
+    bp.A_bus.value = bitarray.util.int2ba(a, 8, endian="little")
+    assert bitarray.util.ba2int(bp.C_bus.value) == 0
+    assert bp.SALU_flag == 0
+
+    c = a << 1
+    if c > 256:
+        rbit, tmp = divmod(c, 256)
+        assert rbit==0 or rbit==1
+        c = tmp
+        c = c + rbit
+
+    target.execute("LBARREL")
+    assert bitarray.util.ba2int(bp.C_bus.value) == c
+    assert bp.SALU_flag == 0
+
+@pytest.mark.parametrize('a', a_vals)
+def test_lshift0(a: int):
+    bp = BackPlane(8)
+    target = SALU(bp)
+    assert a < 256
+
+    bp.A_bus.value = bitarray.util.int2ba(a, 8, endian="little")
+    assert bitarray.util.ba2int(bp.C_bus.value) == 0
+    assert bp.SALU_flag == 0
+
+    c = a << 1
+
+    target.execute("LSHIFT0")
+    assert bitarray.util.ba2int(bp.C_bus.value) == c
+    assert bp.SALU_flag == 0


### PR DESCRIPTION
Add the single operand ALU or `SALU` implementation, along with tests. The `<<` and `>>` operators have a particular implementation for `bitarray` which while it makes sense on its own terms does require an explanation in the comments.