### PR TITLE
Add a Jump Register

### DIFF
--- a/docs/functional_units.md
+++ b/docs/functional_units.md
@@ -17,7 +17,8 @@ We will only specify the process in more detail when clarity requires.
 
 *Functional Selector:* PC
 
-This consists of a 16-bit address register and an 'increment enabled' flag.
+This consists of a 16-bit PC address register, a 16-bit jump register and
+an 'increment enabled' flag.
 
 During the Fetch0 and Fetch1 pipeline stages, it places its value on the A and B buses
 (for Fetch1, the LSB is inverted).
@@ -31,12 +32,37 @@ During the PC Update pipeline stage, the Program Counter will increase its value
 
 This instruction unconditionally copies the contents of the A and B buses to the Program
 Counter, and sets the 'increment enabled' flag to False.
+This happens during the commit pipeline stage.
 
 ### Branch If Zero (PC BRANCHZERO)
 
 If all lines on C bus are zero, copy the contents of the A and B buses to the Program
 Counter and set the 'increment enabled' flag to False. If any of the C bus lines are
-non-zero, make no changes to the Program Counter, and leave 'increment enabled' as True
+non-zero, make no changes to the Program Counter, and leave 'increment enabled' as True.
+This happens during the commit pipeline stage.
+
+### Jump Subroutine (JSR)
+
+Combine A and B buses into an address. Copy the PC to the jump register, and the
+address from the buses into the PC. Inhibit incrementing.
+The PC to JR copy happens during the execute pipeline stage, and the PC update happens during
+the commit pipeline stage
+
+### Return (RET)
+
+Copy the jump register to the PC.
+Do *not* inhibit incrementing.
+This happens during the commit pipeline stage.
+
+### Load Jump Register (LOADJUMP0/LOADJUMP1)
+
+Put the low (0) or high (1) byte of the jump register on C bus.
+This happens during the execute pipeline stage.
+
+### Store Jump Register (STOREJUMP)
+
+Combine A and B buses into an address, and store in the Jump Register.
+This happens during the commit pipeline stage.
 
 
 
@@ -80,13 +106,6 @@ and represented by 'nnn' (base 10) above.
 
 Copy the contents of the status register into Register C.
 The status register itself is left unchanged.
-
-### Load PC (REG LOADPC)
-
-Copy the contents of the Program Counter into Registers
-B (low byte) and C (high byte).
-This should be the only instruction which can write to
-two registers.
 
 
 

--- a/docs/instructions.md
+++ b/docs/instructions.md
@@ -26,10 +26,7 @@ If a particular instruction does not use one or more of the
 registers, those bits may be used for encoding the operation.
 In most cases, register C is being written, and so its input
 will be connected to C bus, not its output.
-This can happen to register B as well, although that is less
-common.
-Register A is always read, and hence its output will always
-be connected to A bus.
+Nothing but the register file can *write* to A and B buses.
 
 ## Program Counter (PC)
 
@@ -38,8 +35,20 @@ be connected to A bus.
 | Instruction | `fff` | Operation | Registers  | Notes |
 |-------------|-------|-----------|------------|-------|
 | BRANCH      | `000` | `0000`    | `aaabbb000`|       |
-| BRANCHZERO  | `100` | `1000`    | `aaabbbccc`| Register C is read      |
+| BRANCHZERO  | `000` | `1000`    | `aaabbbccc`| Register C is read      |
+| STOREJUMP   | `000` | `0100`    | `aaabbb000`|       |
+| JMP         | `000` | `1100`    | `aaabbb000`|       |
+| RET         | `000` | `0010`    | `000000000`| Does not use main registers      |
+| LOAD0       | `000` | `0001`    | `000000ccc`|       |
+| LOAD1       | `000` | `1001`    | `000000ccc`|       |
 
+Note that LOAD0 and LOAD1 are only a single bit different
+their operation code.
+They also have the most significant bit of that operation
+code be a one, and all the others have a zero.
+Also note that the operation code for BRANCHZERO is the same
+as that for MEM STORE below; both operations *read* from 
+register C.
 
 
 ## Memory (MEM)
@@ -51,6 +60,10 @@ be connected to A bus.
 | LOAD        | `100` | `0000`    | `aaabbbccc`|       |
 | STORE       | `100` | `1000`    | `aaabbbccc`| Register C is read      |
 
+Note that the operation code for STORE is the same as for
+PC BRANCHZERO.
+These are the two operations which *read* from register C.
+
 ## Registers (REG)
 
 *Functional Unit:* `010` (2)
@@ -59,7 +72,6 @@ be connected to A bus.
 |-------------|-------|-----------|------------|-------|
 | SETnnn      | `010` | `00vv`    | `vvvvvvccc`| Value is 'nnn' in decimal, and `vvvvvvvv` in little-endian binary      |
 | LOADSTATUS  | `010` | `1000`    | `000000ccc`|       |
-| LOADPC      | `010` | `0100`    | `000bbbccc`| Register B written |
 
 The SETnnn instructions borrow bits from the register selectors.
 
@@ -103,6 +115,6 @@ straightforward. Similar considerations apply to NOT and COPY.
 | AND         | `101` | `0110`    | `aaabbbccc`| Use NAND with inverting 74HC540 buffer      |
 | NAND        | `101` | `1110`    | `aaabbbccc`|       |
 
-The single bit differencein operation code for ADD and
+The single bit difference in operation code for ADD and
 SUB makes a two's complement implementaiton relatively
 straightforward.

--- a/emulator/slothpu/_program_counter.py
+++ b/emulator/slothpu/_program_counter.py
@@ -77,6 +77,10 @@ class ProgramCounter:
     def execute(self, command: str):
         if command == "JSR":
             self._set_jr(self.pc)
+        elif command == "LOADJUMP0":
+            self._backplane.C_bus.value = self._jr[0:8]
+        elif command == "LOADJUMP1":
+            self._backplane.C_bus.value = self._jr[8:16]
         else:
             raise ValueError(f"PC Execute Unrecognised: {command}")
 
@@ -97,6 +101,8 @@ class ProgramCounter:
         elif command == "RET":
             self._set_pc(self.jr)
             self._increment_enable = True
+        elif command == "STOREJUMP":
+            self._set_jr(jump_address)
         else:
             raise ValueError(f"PC Commit Unrecognised: {command}")
 

--- a/emulator/slothpu/_program_counter.py
+++ b/emulator/slothpu/_program_counter.py
@@ -11,6 +11,7 @@ class ProgramCounter:
         self._n_bits = 2 * self._backplane.n_bits
         self._increment_enable = True
         self._pc = bitarray.util.zeros(self.n_bits, endian="little")
+        self._jr = bitarray.util.zeros(self.n_bits, endian="little")
 
     @property
     def pc(self) -> bitarray.bitarray:
@@ -20,6 +21,13 @@ class ProgramCounter:
         return self._pc
 
     @property
+    def jr(self) -> bitarray.bitarray:
+        assert len(self._jr) == self.n_bits
+        assert self._jr.endian() == "little"
+        assert self._jr[0] == 0, "JR must be even"
+        return self._jr
+
+    @property
     def n_bits(self) -> int:
         return self._n_bits
 
@@ -27,8 +35,11 @@ class ProgramCounter:
     def increment_enable(self) -> bool:
         return self._increment_enable
 
-    def get_as_string(self) -> str:
+    def get_pc_as_string(self) -> str:
         return to_01_bigendian(self.pc)
+    
+    def get_jr_as_string(self) -> str:
+        return to_01_bigendian(self.jr)
 
     def _set_pc(self, value: bitarray.bitarray):
         assert isinstance(value, bitarray.bitarray)
@@ -37,6 +48,14 @@ class ProgramCounter:
         assert value[0] == 0, "Must set PC to be even"
         # Make sure we copy
         self._pc = bitarray.bitarray(value)
+
+    def _set_jr(self, value: bitarray.bitarray):
+        assert isinstance(value, bitarray.bitarray)
+        assert len(value) == self.n_bits
+        assert value.endian() == "little"
+        assert value[0] == 0, "Must set PC to be even"
+        # Make sure we copy
+        self.get_jr_as_string = bitarray.bitarray(value)
 
     def increment(self):
         step = bitarray.util.int2ba(2, length=self.n_bits, endian="little")
@@ -56,13 +75,14 @@ class ProgramCounter:
         self._backplane.B_bus.value = self._pc[8:16]
 
     def execute(self, command: str):
+        jump_address = self._backplane.A_bus.value + self._backplane.B_bus.value
         if command == "BRANCH":
             # Copy....
-            target = self._backplane.A_bus.value + self._backplane.B_bus.value
+            target = jump_address
             self._set_pc(target)
             self._increment_enable = False
         elif command == "BRANCH_IF_ZERO":
-            target = self._backplane.A_bus.value + self._backplane.B_bus.value
+            target = jump_address
             if bitarray.util.ba2int(self._backplane.C_bus.value) == 0:
                 self._set_pc(target)
                 self._increment_enable = False

--- a/emulator/slothpu/_program_counter.py
+++ b/emulator/slothpu/_program_counter.py
@@ -94,7 +94,9 @@ class ProgramCounter:
         elif command == "JSR":
             self._set_pc(jump_address)
             self._increment_enable = False
-
+        elif command == "RET":
+            self._set_pc(self.jr)
+            self._increment_enable = True
         else:
             raise ValueError(f"PC Commit Unrecognised: {command}")
 

--- a/emulator/slothpu/_program_counter.py
+++ b/emulator/slothpu/_program_counter.py
@@ -37,7 +37,7 @@ class ProgramCounter:
 
     def get_pc_as_string(self) -> str:
         return to_01_bigendian(self.pc)
-    
+
     def get_jr_as_string(self) -> str:
         return to_01_bigendian(self.jr)
 

--- a/emulator/slothpu/_register_file.py
+++ b/emulator/slothpu/_register_file.py
@@ -50,7 +50,6 @@ class RegisterFile:
         assert idx >= 0 and idx < len(self._registers)
         self._C_register = idx
 
-
     @property
     def write_C_register(self) -> bool:
         return self._write_C_register

--- a/emulator/slothpu/_register_file.py
+++ b/emulator/slothpu/_register_file.py
@@ -7,7 +7,6 @@ class RegisterFile:
         self._backplane = backplane
         self._n_bits = self._backplane.n_bits
         self._registers = Memory(n_registers, self.n_bits)
-        self._write_B_register = False
         self._write_C_register = False
         self._A_register = 0
         self._B_register = 0
@@ -51,13 +50,6 @@ class RegisterFile:
         assert idx >= 0 and idx < len(self._registers)
         self._C_register = idx
 
-    @property
-    def write_B_register(self) -> bool:
-        return self._write_B_register
-
-    @write_B_register.setter
-    def write_B_register(self, value: bool) -> bool:
-        self._write_B_register = value
 
     @property
     def write_C_register(self) -> bool:
@@ -67,17 +59,13 @@ class RegisterFile:
     def write_C_register(self, value: bool) -> bool:
         self._write_C_register = value
 
-    def execute(self, command: str):
-        if command == "RegisterRead":
-            self._backplane.A_bus.value = self._registers[self.A_register]
-            if not self.write_B_register:
-                self._backplane.B_bus.value = self._registers[self.B_register]
-            if not self.write_C_register:
-                self._backplane.C_bus.value = self._registers[self.C_register]
-        elif command == "RegisterWrite":
-            if self.write_B_register:
-                self._registers[self.B_register] = self._backplane.B_bus.value
-            if self.write_C_register:
-                self._registers[self.C_register] = self._backplane.C_bus.value
-        else:
-            raise ValueError(f"RegisterFile unrecognised command : {command}")
+    def decode(self):
+        # Registers are placed on the backplane during the 'decode' step
+        self._backplane.A_bus.value = self._registers[self.A_register]
+        self._backplane.B_bus.value = self._registers[self.B_register]
+        if not self.write_C_register:
+            self._backplane.C_bus.value = self._registers[self.C_register]
+
+    def commit(self):
+        assert self._write_C_register is True
+        self._registers[self.C_register] = self._backplane.C_bus.value

--- a/emulator/slothpu/_slothpu.py
+++ b/emulator/slothpu/_slothpu.py
@@ -64,8 +64,8 @@ class SlothPU:
 
             # B and C are more complex and TBD...
             self.register_file.A_register = self.instruction_register.R_A
-            self.register_file.write_B_register = True  # TO BE UPDATED!
-            self.register_file.execute("RegisterRead")
+            self.register_file.A_register = self.instruction_register.R_B
+            self.register_file.decode()
         elif self._pipeline_stage == 3:
             # Execute
             # PARTIALLY COMPLETE

--- a/emulator/slothpu/interface/_program_counter_widget.py
+++ b/emulator/slothpu/interface/_program_counter_widget.py
@@ -8,9 +8,10 @@ class ProgramCounterWidget(urwid.WidgetWrap):
         self._pc = pc
 
         self._pc_text = urwid.Text("")
+        self._jr_text = urwid.Text("")
         self._inc_enable_text = urwid.Text("")
 
-        pc_pile = urwid.Pile([self._pc_text, self._inc_enable_text])
+        pc_pile = urwid.Pile([self._pc_text, self._jr_text, self._inc_enable_text])
 
         pc_box = urwid.LineBox(pc_pile, title="Program Counter", title_align=urwid.LEFT)
         self.update()
@@ -18,5 +19,6 @@ class ProgramCounterWidget(urwid.WidgetWrap):
         super(ProgramCounterWidget, self).__init__(pc_box)
 
     def update(self):
-        self._pc_text.set_text(self._pc.get_as_string())
+        self._pc_text.set_text(f"PC: {self._pc.get_pc_as_string()}")
+        self._jr_text.set_text(f"JR: {self._pc.get_jr_as_string()}")
         self._inc_enable_text.set_text(f"Increment Enable: {self._pc.increment_enable}")

--- a/emulator/slothpu/interface/_register_file_widget.py
+++ b/emulator/slothpu/interface/_register_file_widget.py
@@ -32,9 +32,7 @@ class RegisterFileWidget(urwid.WidgetWrap):
         for i in range(len(self._register_output)):
             self._register_output[i].set_text(self.format_register_string(i))
         self._A_text.set_text(self.format_regX_string("A", self._rf.A_register))
-        self._B_text.set_text(
-            self.format_regX_string("B", self._rf.B_register, self._rf.write_B_register)
-        )
+        self._B_text.set_text(self.format_regX_string("B", self._rf.B_register))
         self._C_text.set_text(
             self.format_regX_string("C", self._rf.C_register, self._rf.write_C_register)
         )

--- a/emulator/test/test_program_counter.py
+++ b/emulator/test/test_program_counter.py
@@ -87,7 +87,7 @@ def test_fetch1():
     assert bitarray.util.ba2int(target.jr) == 0
 
 
-def test_execute_branch():
+def test_branch():
     bp = BackPlane(8)
     target = ProgramCounter(bp)
 
@@ -105,7 +105,7 @@ def test_execute_branch():
     assert bitarray.util.ba2int(target.jr) == 0
 
 
-def test_execute_branch_if_zero():
+def test_branch_if_zero():
     bp = BackPlane(8)
     target = ProgramCounter(bp)
 
@@ -141,7 +141,7 @@ def test_execute_branch_if_zero():
     assert bitarray.util.ba2int(target.jr) == 0
 
 
-def test_execute_jsr():
+def test_jsr():
     bp = BackPlane(8)
     target = ProgramCounter(bp)
 

--- a/emulator/test/test_program_counter.py
+++ b/emulator/test/test_program_counter.py
@@ -8,20 +8,24 @@ def test_smoke():
     target = ProgramCounter(bp)
 
     assert bitarray.util.ba2int(target.pc) == 0
+    assert bitarray.util.ba2int(target.jr) == 0
 
 
 def test_increment():
     bp = BackPlane(8)
     target = ProgramCounter(bp)
+    assert bitarray.util.ba2int(target.jr) == 0
 
     assert bitarray.util.ba2int(target.pc) == 0
     target.increment()
     assert bitarray.util.ba2int(target.pc) == 2
+    assert bitarray.util.ba2int(target.jr) == 0
 
 
 def test_updatepc():
     bp = BackPlane(8)
     target = ProgramCounter(bp)
+    assert bitarray.util.ba2int(target.jr) == 0
 
     assert bitarray.util.ba2int(target.pc) == 0
     target.updatepc()
@@ -30,6 +34,7 @@ def test_updatepc():
     target._increment_enable = False
     target.updatepc()
     assert bitarray.util.ba2int(target.pc) == 4
+    assert bitarray.util.ba2int(target.jr) == 0
 
 
 def test_fetch0():
@@ -56,6 +61,7 @@ def test_fetch0():
     assert bitarray.util.ba2int(bp.B_bus.value) == expect_b
     # FETCH0 should re-enable increment
     assert target.increment_enable is True
+    assert bitarray.util.ba2int(target.jr) == 0
 
 
 def test_fetch1():
@@ -78,6 +84,7 @@ def test_fetch1():
     expect_b, expect_a = divmod(start_loc + 1, 2**bp.n_bits)
     assert bitarray.util.ba2int(bp.A_bus.value) == expect_a
     assert bitarray.util.ba2int(bp.B_bus.value) == expect_b
+    assert bitarray.util.ba2int(target.jr) == 0
 
 
 def test_execute_branch():
@@ -95,6 +102,7 @@ def test_execute_branch():
     target.execute("BRANCH")
     assert bitarray.util.ba2int(target.pc) == loc
     assert not target.increment_enable
+    assert bitarray.util.ba2int(target.jr) == 0
 
 
 def test_execute_branch_if_zero():
@@ -130,3 +138,4 @@ def test_execute_branch_if_zero():
     target.execute("BRANCH_IF_ZERO")
     assert bitarray.util.ba2int(target.pc) == jump_loc
     assert target.increment_enable is False
+    assert bitarray.util.ba2int(target.jr) == 0

--- a/emulator/test/test_program_counter.py
+++ b/emulator/test/test_program_counter.py
@@ -146,7 +146,7 @@ def test_jsr():
     target = ProgramCounter(bp)
 
     start_loc = 3512
-    subroutine_loc = 5684
+    subroutine_loc = 7932
 
     # Push the inital PC value
     loc_ba = bitarray.util.int2ba(start_loc, target.n_bits, endian="little")
@@ -168,3 +168,27 @@ def test_jsr():
     assert bitarray.util.ba2int(target.pc) == subroutine_loc
     assert target.increment_enable is False
 
+def test_ret():
+    bp = BackPlane(8)
+    target = ProgramCounter(bp)
+
+    start_loc = 3512
+
+    # Push the inital PC value
+    loc_ba = bitarray.util.int2ba(start_loc, target.n_bits, endian="little")
+    bp.A_bus.value = loc_ba[0:8]
+    bp.B_bus.value = loc_ba[8:16]
+    target.commit("BRANCH")
+    assert bitarray.util.ba2int(target.pc) == start_loc
+    assert bitarray.util.ba2int(target.jr) == 0
+
+    # Now set up A & B with some random value
+    loc_ba = bitarray.util.int2ba(8848, target.n_bits, endian="little")
+    bp.A_bus.value = loc_ba[0:8]
+    bp.B_bus.value = loc_ba[8:16]
+
+    # Now do the return
+    target.commit("RET")
+    assert bitarray.util.ba2int(target.pc) == 0
+    assert bitarray.util.ba2int(target.jr) == 0
+    assert target.increment_enable is True

--- a/emulator/test/test_program_counter.py
+++ b/emulator/test/test_program_counter.py
@@ -168,6 +168,7 @@ def test_jsr():
     assert bitarray.util.ba2int(target.pc) == subroutine_loc
     assert target.increment_enable is False
 
+
 def test_ret():
     bp = BackPlane(8)
     target = ProgramCounter(bp)
@@ -192,6 +193,7 @@ def test_ret():
     assert bitarray.util.ba2int(target.pc) == 0
     assert bitarray.util.ba2int(target.jr) == 0
     assert target.increment_enable is True
+
 
 def test_store_load_jr():
     bp = BackPlane(8)

--- a/emulator/test/test_register_file.py
+++ b/emulator/test/test_register_file.py
@@ -20,11 +20,10 @@ def test_smoke():
     assert target.B_register == 2
     assert target.C_register == 3
 
-    assert target.write_B_register is False
     assert target.write_C_register is False
 
 
-def test_execute_registerread_all():
+def test_decode_all():
     bp = BackPlane(n_bits=8)
     target = RegisterFile(8, bp)
 
@@ -32,14 +31,15 @@ def test_execute_registerread_all():
     target.B_register = 6
     target.C_register = 7
 
-    target.execute("RegisterRead")
+    # Registers are connected to bus during decode step
+    target.decode()
     # Registers initialised with their index
     assert bitarray.util.ba2int(bp.A_bus.value) == 4
     assert bitarray.util.ba2int(bp.B_bus.value) == 6
     assert bitarray.util.ba2int(bp.C_bus.value) == 7
 
 
-def test_execute_registerread_notC():
+def test_decode_notC():
     bp = BackPlane(n_bits=8)
     target = RegisterFile(8, bp)
 
@@ -49,7 +49,8 @@ def test_execute_registerread_notC():
 
     target.write_C_register = True
 
-    target.execute("RegisterRead")
+    # Registers are connected to bus during decode step
+    target.decode()
     # Registers initialised with their index
     assert bitarray.util.ba2int(bp.A_bus.value) == 4
     assert bitarray.util.ba2int(bp.B_bus.value) == 6
@@ -57,43 +58,7 @@ def test_execute_registerread_notC():
     assert bitarray.util.ba2int(bp.C_bus.value) == 0
 
 
-def test_execute_registerread_notB():
-    bp = BackPlane(n_bits=8)
-    target = RegisterFile(8, bp)
-
-    target.A_register = 4
-    target.B_register = 6
-    target.C_register = 7
-
-    target.write_B_register = True
-
-    target.execute("RegisterRead")
-    # Registers initialised with their index
-    # Buses initialised to zero
-    assert bitarray.util.ba2int(bp.A_bus.value) == 4
-    assert bitarray.util.ba2int(bp.B_bus.value) == 0
-    assert bitarray.util.ba2int(bp.C_bus.value) == 7
-
-
-def test_execut_registerwrite_B():
-    bp = BackPlane(n_bits=8)
-    write_value = 234
-    bp.B_bus.value = bitarray.util.int2ba(write_value, 8, endian="little")
-    target = RegisterFile(8, bp)
-
-    target.A_register = 4
-    target.B_register = 6
-    target.C_register = 7
-
-    target.write_B_register = True
-
-    target.execute("RegisterWrite")
-    assert bitarray.util.ba2int(target.registers[target.A_register]) == 4
-    assert bitarray.util.ba2int(target.registers[target.B_register]) == write_value
-    assert bitarray.util.ba2int(target.registers[target.C_register]) == 7
-
-
-def test_execut_registerwrite_C():
+def test_execute_registerwrite_C():
     bp = BackPlane(n_bits=8)
     write_value = 21
     bp.C_bus.value = bitarray.util.int2ba(write_value, 8, endian="little")
@@ -105,7 +70,7 @@ def test_execut_registerwrite_C():
 
     target.write_C_register = True
 
-    target.execute("RegisterWrite")
+    target.commit()
     assert bitarray.util.ba2int(target.registers[target.A_register]) == 4
     assert bitarray.util.ba2int(target.registers[target.B_register]) == 2
     assert bitarray.util.ba2int(target.registers[target.C_register]) == write_value


### PR DESCRIPTION
After some thought, it feels better to have a dedicated Jump register built into the program counter. This helps deal with the design having 8-bit registers but using 16-bit addressing, which had lead to needing the instruction to copy the PC to be able to write to *two* registers. It was the only instruction which needed to do so, and complicated the register file. Having a jump register avoids this, since it is safe to copy the low and high bytes with separate instructions. I believe that this compensates for the extra instructions now in the Program Counter.

Closes #19 