### PR TITLE
Initialise main memory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,4 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+emulator/.vscode/settings.json

--- a/emulator/assembler.py
+++ b/emulator/assembler.py
@@ -19,12 +19,12 @@ def build_argument_parser():
 
     parser = argparse.ArgumentParser(description=desc)
     parser.add_argument(
-        "--assembler-filename",
+        "--assembler-file",
         help="The file containing the assembly code",
         required=True,
     )
     parser.add_argument(
-        "--output-filename",
+        "--output-file",
         help="The file containing the encoded output",
         required=True,
     )
@@ -129,7 +129,7 @@ def assemble_salu_instruction(parts: List[str]) -> bitarray.bitarray:
     return instruction_ba
 
 
-def process_line(line: str, current_location: int) -> bitarray.bitarray:
+def process_assembler_line(line: str, current_location: int) -> bitarray.bitarray:
     # Remove any trailing comments
     instruction_line = line.split(comment_char)[0]
 
@@ -157,33 +157,38 @@ def process_line(line: str, current_location: int) -> bitarray.bitarray:
     _logger.info(f"{result} : {instruction_parts}")
     return result
 
+def process_lines(lines: List[str])-> List[int]:
+    machine_code = []
+    for curr_line in lines:
+        line = curr_line.strip()
+        if empty_or_comment(line):
+            continue
+
+        nxt_instruction = process_assembler_line(line, len(machine_code))
+
+        machine_code.append(bitarray.util.ba2int(nxt_instruction[0:8]))
+        machine_code.append(bitarray.util.ba2int(nxt_instruction[8:16]))
+    _logger.info("Assembly complete")
+    return machine_code
+
 
 def main():
     parser = build_argument_parser()
     args = parser.parse_args()
 
-    _logger.info(f"Parsing: {args.assembler_filename}")
+    _logger.info(f"Parsing: {args.assembler_file}")
 
     # Read in the file
-    with open(args.assembler_filename) as assembler_file:
-        raw_lines = assembler_file.readlines()
+    with open(args.assembler_file) as f_assembler:
+        raw_lines = f_assembler.readlines()
     lines = [line.strip() for line in raw_lines]
     _logger.info(f"Found {len(lines)} lines")
 
     # List to hold the result
-    machine_code = []
-    for line in lines:
-        if empty_or_comment(line):
-            continue
+    machine_code = process_lines(lines)
 
-        nxt_instruction = process_line(line, len(machine_code))
-
-        machine_code.append(bitarray.util.ba2int(nxt_instruction[0:8]))
-        machine_code.append(bitarray.util.ba2int(nxt_instruction[8:16]))
-    _logger.info("Assembly complete")
-
-    _logger.info(f"Writing {args.output_filename}")
-    with open(args.output_filename, "w") as of:
+    _logger.info(f"Writing {args.output_file}")
+    with open(args.output_file, "w") as of:
         for c in machine_code:
             of.write(f"{c}\n")
     _logger.info("File written")

--- a/emulator/assembler.py
+++ b/emulator/assembler.py
@@ -157,7 +157,8 @@ def process_assembler_line(line: str, current_location: int) -> bitarray.bitarra
     _logger.info(f"{result} : {instruction_parts}")
     return result
 
-def process_lines(lines: List[str])-> List[int]:
+
+def process_lines(lines: List[str]) -> List[int]:
     machine_code = []
     for curr_line in lines:
         line = curr_line.strip()

--- a/emulator/run_slothpu.py
+++ b/emulator/run_slothpu.py
@@ -1,5 +1,31 @@
+import argparse
+
+from assembler import process_lines
+
 from slothpu.interface import SlothPU_Interface
 
+def build_argparser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--assembler-file",
+        help="The file containing the assembly code",
+        required=True,
+    )
 
-spu = SlothPU_Interface()
-spu.main()
+    return parser
+
+
+def main():
+    parser = build_argparser()
+    args = parser.parse_args()
+
+    with open(args.assembler_file) as f_assembler:
+        raw_lines = f_assembler.readlines()
+    initial_memory = process_lines(raw_lines)
+
+    spu = SlothPU_Interface(initial_memory)
+    spu.main()
+
+
+if __name__ == "__main__":
+    main()

--- a/emulator/run_slothpu.py
+++ b/emulator/run_slothpu.py
@@ -4,6 +4,7 @@ from assembler import process_lines
 
 from slothpu.interface import SlothPU_Interface
 
+
 def build_argparser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser()
     parser.add_argument(

--- a/emulator/slothpu/_main_memory.py
+++ b/emulator/slothpu/_main_memory.py
@@ -9,7 +9,9 @@ from ._memory import Memory
 class MainMemory:
     main_memory_address_bits = 14
 
-    def __init__(self, backplane: BackPlane, initial_memory: Optional[List[int]] = None):
+    def __init__(
+        self, backplane: BackPlane, initial_memory: Optional[List[int]] = None
+    ):
         assert backplane is not None
         assert isinstance(backplane, BackPlane)
         self._backplane = backplane
@@ -21,8 +23,9 @@ class MainMemory:
             for i, v in enumerate(initial_memory):
                 assert v < 256
                 assert i < len(self._memory)
-                self._memory[i] = bitarray.util.int2ba(v,self._backplane.n_bits, endian="little")
-
+                self._memory[i] = bitarray.util.int2ba(
+                    v, self._backplane.n_bits, endian="little"
+                )
 
     @property
     def memory(self) -> Memory:

--- a/emulator/slothpu/_main_memory.py
+++ b/emulator/slothpu/_main_memory.py
@@ -1,3 +1,5 @@
+from typing import List, Optional
+
 import bitarray.util
 
 from ._backplane import BackPlane
@@ -7,7 +9,7 @@ from ._memory import Memory
 class MainMemory:
     main_memory_address_bits = 14
 
-    def __init__(self, backplane: BackPlane):
+    def __init__(self, backplane: BackPlane, initial_memory: Optional[List[int]] = None):
         assert backplane is not None
         assert isinstance(backplane, BackPlane)
         self._backplane = backplane
@@ -15,6 +17,12 @@ class MainMemory:
             n_locations=2**MainMemory.main_memory_address_bits,
             n_bits=self._backplane.n_bits,
         )
+        if initial_memory is not None:
+            for i, v in enumerate(initial_memory):
+                assert v < 256
+                assert i < len(self._memory)
+                self._memory[i] = bitarray.util.int2ba(v,self._backplane.n_bits, endian="little")
+
 
     @property
     def memory(self) -> Memory:

--- a/emulator/slothpu/_slothpu.py
+++ b/emulator/slothpu/_slothpu.py
@@ -36,7 +36,6 @@ class SlothPU:
         self._salu = SALU(self.backplane)
         self._dalu = DALU(self.backplane)
 
-
     @property
     def pipeline_stage(self) -> str:
         assert self._pipeline_stage < n_pipeline_stages

--- a/emulator/slothpu/_slothpu.py
+++ b/emulator/slothpu/_slothpu.py
@@ -1,3 +1,5 @@
+from typing import List, Optional
+
 from ._backplane import BackPlane
 from ._dalu import DALU
 from ._instruction_register import InstructionRegister
@@ -22,17 +24,18 @@ n_bits_per_byte = 8
 
 
 class SlothPU:
-    def __init__(self):
+    def __init__(self, initial_memory: Optional[List[int]] = None):
         self._pipeline_stage: int = n_pipeline_stages - 1
         self.n_registers = 8
         self._backplane = BackPlane(n_bits_per_byte)
-        self._main_memory = MainMemory(self.backplane)
+        self._main_memory = MainMemory(self.backplane, initial_memory)
         self._register_file = RegisterFile(self.n_registers, self.backplane)
         self._program_counter = ProgramCounter(self._backplane)
         self._instruction_register = InstructionRegister(self._backplane)
         self._status_register = StatusRegister(self._backplane)
         self._salu = SALU(self.backplane)
         self._dalu = DALU(self.backplane)
+
 
     @property
     def pipeline_stage(self) -> str:

--- a/emulator/slothpu/interface/_slothpu_interface.py
+++ b/emulator/slothpu/interface/_slothpu_interface.py
@@ -17,7 +17,7 @@ def top_handler(key):
 
 
 class SlothPU_Interface:
-    def __init__(self,initial_memory: Optional[List[int]] = None):
+    def __init__(self, initial_memory: Optional[List[int]] = None):
         self._target = SlothPU(initial_memory=initial_memory)
 
         control_column = ControlColumn(self._target)

--- a/emulator/slothpu/interface/_slothpu_interface.py
+++ b/emulator/slothpu/interface/_slothpu_interface.py
@@ -1,3 +1,5 @@
+from typing import List, Optional
+
 import urwid
 
 from slothpu import SlothPU
@@ -15,8 +17,8 @@ def top_handler(key):
 
 
 class SlothPU_Interface:
-    def __init__(self):
-        self._target = SlothPU()
+    def __init__(self,initial_memory: Optional[List[int]] = None):
+        self._target = SlothPU(initial_memory=initial_memory)
 
         control_column = ControlColumn(self._target)
         register_column = RegisterColumn(self._target)

--- a/emulator/test/test_main_memory.py
+++ b/emulator/test/test_main_memory.py
@@ -6,7 +6,6 @@ from slothpu import BackPlane, MainMemory
 def test_smoke():
     n_bits = 8
     bp = BackPlane(n_bits)
-
     target = MainMemory(bp)
 
     target_loc = 4000
@@ -27,3 +26,20 @@ def test_smoke():
     bp.C_bus.value = bitarray.util.zeros(8, endian="little")
     target.execute("READ")
     assert bitarray.util.ba2int(bp.C_bus.value) == write_value
+
+
+def test_smoke_initialise():
+    initial_values = [234, 253, 0, 123, 240, 197]
+    assert len(initial_values) < 2**14
+
+    n_bits = 8
+    bp = BackPlane(n_bits)
+    target = MainMemory(bp, initial_memory=initial_values)
+
+    for i, v in enumerate(initial_values):
+        addr_ba = bitarray.util.int2ba(i, 16, endian="little")
+        bp.A_bus.value = addr_ba[0:8]
+        bp.B_bus.value = addr_ba[8:16]
+        target.execute("READ")
+        assert bitarray.util.ba2int(bp.C_bus.value) == v
+

--- a/emulator/test/test_main_memory.py
+++ b/emulator/test/test_main_memory.py
@@ -42,4 +42,3 @@ def test_smoke_initialise():
         bp.B_bus.value = addr_ba[8:16]
         target.execute("READ")
         assert bitarray.util.ba2int(bp.C_bus.value) == v
-


### PR DESCRIPTION
Allow initialisation of main memory from a list of integers. Modify the `run_slothpu.py` script to call into the assembler (which should probably be refactored).