### PR TITLE
Two Byte add with subroutine

### DIFF
--- a/emulator/sample_programs/simple_two_byte_add.txt
+++ b/emulator/sample_programs/simple_two_byte_add.txt
@@ -76,7 +76,7 @@
 66 PC BRANCHZERO R1 R0 R4  # Test the carry bit
 68 SALU INC R3 R3
 
-# Save out the high bit
+# Save out the high byte
 70 SALU INC R6 R6
 72 SALU INC R6 R6
 74 MEM STORE R6 R7 R3

--- a/emulator/sample_programs/subroutine_two_byte_add.txt
+++ b/emulator/sample_programs/subroutine_two_byte_add.txt
@@ -43,24 +43,55 @@
 # So next, we need to copy A and B into the
 # stack location
 
-30 REG SET000 R0
+30 REG SET128 R0
 
 # Do the copy in a loop. Use R3 as loop counter
 32 REG SET004 R3
 
 # Use R4 to point back to the top of the loop
-# Will also reuse R0 here
+# Will also reuse R1 (set to 000) here
+# Trying to manipulate 16-bit addresses with 8-bit
+# registers burns through them really fast....
 
 34 REG SET038 R4 # Address of loop top
 36 REG SET052 R5 # Address of loop exit
 
-38 PC BRANCHZERO R5 R0 R3 # Start of the loop
+38 PC BRANCHZERO R5 R1 R3 # Start of the loop
 
 40 MEM LOAD R0 R1 R2
 42 MEM STORE R6 R7 R2
-44 SALU INC R0
-46 SALU INC R6
-48 SALU DEC R3
-50 PC BRANCH R4 R0 # End of loop body
+44 SALU INC R0 R0
+46 SALU INC R6 R6
+48 SALU DEC R3 R3
+50 PC BRANCH R4 R1 # End of loop body
 
-52 REG SET000 R6 # Reset the offset pointer
+52 REG SET084 R0   # Point to start of the subroutine
+
+54 PC JSR R0 R1 # Go to the subroutine
+
+# Now copy the result out of the subroutine's
+# stack frame. The only register we can count on 
+# is R7
+# We will extract the results to locations 132 and 133
+56 REG SET000 R1
+58 REG SET132 R0
+60 REG SET003 R6 # Off set of result_lo in the stack frame
+
+62 MEM LOAD R6 R7 R2
+64 MEM STORE R0 R1 R2
+66 SALU INC R6 R6
+68 SALU INC R0 R0
+70 MEM LOAD R6 R7 R2
+72 MEM STORE R0 R1 R2
+
+# The program is now done, so go into a loop
+
+74 REG SET076 R0
+76 REG SET000 R2
+78 REG SET000 R6
+80 REG SET000 R7
+82 PC BRANCH R0 R1
+
+# ----------
+
+# Now the subroutine

--- a/emulator/sample_programs/subroutine_two_byte_add.txt
+++ b/emulator/sample_programs/subroutine_two_byte_add.txt
@@ -7,11 +7,11 @@
 # B = 9487 (37*256 + 15)
 
 # Start by poking these values into our 'main' memory
-# beginning at location 128. The order will be
+# beginning at location 160. The order will be
 # A_lo, A_hi, B_lo, B_hi
 
 # Set up address registers
- 0 REG SET128 R0
+ 0 REG SET160 R0
  2 REG SET000 R1
 
 # Store A
@@ -29,6 +29,7 @@
 22 REG SET037 R2
 24 MEM STORE R0 R1 R2
 
+# ---------------------------
 
 # We will use R7 as the 'stack pointer'
 # Each stack will be exactly 256 bytes, which
@@ -43,7 +44,7 @@
 # So next, we need to copy A and B into the
 # stack location
 
-30 REG SET128 R0
+30 REG SET160 R0
 
 # Do the copy in a loop. Use R3 as loop counter
 32 REG SET004 R3
@@ -72,10 +73,10 @@
 # Now copy the result out of the subroutine's
 # stack frame. The only register we can count on 
 # is R7
-# We will extract the results to locations 132 and 133
+# We will extract the results to locations 164 and 165
 56 REG SET000 R1
-58 REG SET132 R0
-60 REG SET003 R6 # Off set of result_lo in the stack frame
+58 REG SET164 R0
+60 REG SET003 R6 # Offset of result_lo in the stack frame
 
 62 MEM LOAD R6 R7 R2
 64 MEM STORE R0 R1 R2
@@ -95,3 +96,56 @@
 # ----------
 
 # Now the subroutine
+# We can assume that R7 is set for our stackframe
+# The first four bytes are
+# a_lo, a_hi, b_lo, b_hi
+# We then need to put result_lo and result_hi into
+# the next two bytes
+
+84 REG SET000 R6
+
+# Load the two low bytes into R1 and R2
+86 MEM LOAD R6 R7 R1
+88 SALU INC R6 R6
+90 SALU INC R6 R6
+92 MEM LOAD R6 R7 R2
+
+# Add the two low bytes store in R3
+94 DALU ADD R1 R2 R3
+# Grab the status register
+96 REG LOADSTATUS R4
+
+# Now store R4 into the low byte of the answer
+98 SALU INC R6 R6
+100 SALU INC R6 R6
+102 MEM STORE R6 R7 R3
+
+# Mask the status register for the DALU flag
+# DALU flag is in the second bit of the status register
+104 REG SET002 R2
+106 DALU AND R2 R4 R4 # R4 now just holds the carry bit
+
+# Now we add the two high bytes into R1 and R2
+108 REG SET001 R6
+110 MEM LOAD R6 R7 R1
+112 SALU INC R6 R6
+114 SALU INC R6 R6
+116 MEM LOAD R6 R7 R2
+
+# Do R1 + R2 -> R3
+118 DALU ADD R1 R2 R3
+
+# If we had a carry from the low byte
+# we need to increment
+120 REG SET000 R0
+122 REG SET128 R1 # First instruction past the INC
+124 PC BRANCHZERO R1 R0 R4  # Test the carry bit
+126 SALU INC R3 R3
+
+# Save out the high byte
+128 SALU INC R6 R6
+130 SALU INC R6 R6
+132 MEM STORE R6 R7 R3
+
+# Finally, return
+134 RET

--- a/emulator/sample_programs/subroutine_two_byte_add.txt
+++ b/emulator/sample_programs/subroutine_two_byte_add.txt
@@ -5,6 +5,8 @@
 # We will add
 # A = 29753 (116 * 256 + 57)
 # B = 9487 (37*256 + 15)
+# which makes
+# C = 39240 (153*256 + 72)
 
 # Start by poking these values into our 'main' memory
 # beginning at location 160. The order will be
@@ -76,7 +78,7 @@
 # We will extract the results to locations 164 and 165
 56 REG SET000 R1
 58 REG SET164 R0
-60 REG SET003 R6 # Offset of result_lo in the stack frame
+60 REG SET004 R6 # Offset of result_lo in the stack frame
 
 62 MEM LOAD R6 R7 R2
 64 MEM STORE R0 R1 R2
@@ -148,4 +150,4 @@
 132 MEM STORE R6 R7 R3
 
 # Finally, return
-134 RET
+134 PC RET

--- a/emulator/sample_programs/subroutine_two_byte_add.txt
+++ b/emulator/sample_programs/subroutine_two_byte_add.txt
@@ -26,7 +26,8 @@
 16 REG SET015 R2
 18 MEM STORE R0 R1 R2
 20 SALU INC R0 R0
-22 MEM STORE R0 R1 R2
+22 REG SET037 R2
+24 MEM STORE R0 R1 R2
 
 
 # We will use R7 as the 'stack pointer'
@@ -34,5 +35,32 @@
 # enables us to track the stack with a single
 # register (which contains the _high_ byte)
 
-24 REG SET001 R7 # Location of our stack
-26 REG SET000 R6 # Current offset within the stack
+26 REG SET001 R7 # Location of our stack
+28 REG SET000 R6 # Current offset within the stack
+
+# We we lay out the stack frame as follows:
+# A_lo, A_hi, B_lo, B_hi, result_lo, result_hi
+# So next, we need to copy A and B into the
+# stack location
+
+30 REG SET000 R0
+
+# Do the copy in a loop. Use R3 as loop counter
+32 REG SET004 R3
+
+# Use R4 to point back to the top of the loop
+# Will also reuse R0 here
+
+34 REG SET038 R4 # Address of loop top
+36 REG SET052 R5 # Address of loop exit
+
+38 PC BRANCHZERO R5 R0 R3 # Start of the loop
+
+40 MEM LOAD R0 R1 R2
+42 MEM STORE R6 R7 R2
+44 SALU INC R0
+46 SALU INC R6
+48 SALU DEC R3
+50 PC BRANCH R4 R0 # End of loop body
+
+52 REG SET000 R6 # Reset the offset pointer

--- a/emulator/sample_programs/subroutine_two_byte_add.txt
+++ b/emulator/sample_programs/subroutine_two_byte_add.txt
@@ -1,0 +1,38 @@
+# Two Byte Addition with subroutine
+
+# Adds two 2-byte numbers together using a subroutine
+
+# We will add
+# A = 29753 (116 * 256 + 57)
+# B = 9487 (37*256 + 15)
+
+# Start by poking these values into our 'main' memory
+# beginning at location 128. The order will be
+# A_lo, A_hi, B_lo, B_hi
+
+# Set up address registers
+ 0 REG SET128 R0
+ 2 REG SET000 R1
+
+# Store A
+ 4 REG SET057 R2
+ 6 MEM STORE R0 R1 R2
+ 8 SALU INC R0 R0
+10 REG SET116 R2
+12 MEM STORE R0 R1 R2
+
+# Store B
+14 SALU INC R0 R0
+16 REG SET015 R2
+18 MEM STORE R0 R1 R2
+20 SALU INC R0 R0
+22 MEM STORE R0 R1 R2
+
+
+# We will use R7 as the 'stack pointer'
+# Each stack will be exactly 256 bytes, which
+# enables us to track the stack with a single
+# register (which contains the _high_ byte)
+
+24 REG SET001 R7 # Location of our stack
+26 REG SET000 R6 # Current offset within the stack

--- a/emulator/slothpu/_assembler.py
+++ b/emulator/slothpu/_assembler.py
@@ -58,6 +58,14 @@ def assemble_pc_instruction(parts: List[str]) -> bitarray.bitarray:
         R_B = parse_register_part(parts[4])
         R_C = parse_register_part(parts[5])
         op_ba = bitarray.bitarray("1000", endian="little")
+    elif operation == "JSR":
+        assert len(parts) == 5
+        R_A = parse_register_part(parts[3])
+        R_B = parse_register_part(parts[4])
+        op_ba = bitarray.bitarray("1100", endian="little")
+    elif operation == "RET":
+        assert len(parts == 2)
+        op_ba = bitarray.bitarray("0010", endian="little")
     else:
         raise ValueError(f"PC unrecognised operation: {operation}")
 

--- a/emulator/slothpu/_assembler.py
+++ b/emulator/slothpu/_assembler.py
@@ -64,7 +64,7 @@ def assemble_pc_instruction(parts: List[str]) -> bitarray.bitarray:
         R_B = parse_register_part(parts[4])
         op_ba = bitarray.bitarray("1100", endian="little")
     elif operation == "RET":
-        assert len(parts == 2)
+        assert len(parts) == 3
         op_ba = bitarray.bitarray("0010", endian="little")
     else:
         raise ValueError(f"PC unrecognised operation: {operation}")

--- a/emulator/test/test_e2e.py
+++ b/emulator/test/test_e2e.py
@@ -8,22 +8,23 @@ import pytest
 from slothpu import SlothPU, assemble_lines
 
 
-a_b_pairs =     [
-        (0, 0),
-        (1, 0),
-        (0, 1),
-        (255, 1),
-        (1, 255),
-        (0, 256),
-        (1, 256),
-        (256, 0),
-        (256, 1),
-        (16384, 16385),
-        (1, 65534),
-        (65534, 1),
-        (32768, 32767),
-        (10542, 6583),
-    ]
+a_b_pairs = [
+    (0, 0),
+    (1, 0),
+    (0, 1),
+    (255, 1),
+    (1, 255),
+    (0, 256),
+    (1, 256),
+    (256, 0),
+    (256, 1),
+    (16384, 16385),
+    (1, 65534),
+    (65534, 1),
+    (32768, 32767),
+    (10542, 6583),
+]
+
 
 def load_sample_program(prog_name: str) -> List[str]:
     prog_dir = "sample_programs"
@@ -213,10 +214,7 @@ def test_simple_two_byte_add():
     assert c_hi == bitarray.util.ba2int(target.main_memory.memory[261])
 
 
-@pytest.mark.parametrize(
-    ["a", "b"],
-    a_b_pairs
-)
+@pytest.mark.parametrize(["a", "b"], a_b_pairs)
 def test_simple_two_byte_add_vals(a: int, b: int):
     prog_lines = load_sample_program("simple_two_byte_add.txt")
 
@@ -287,22 +285,18 @@ def test_subroutine_two_byte_add():
         target.advance_instruction()
         # 2 bytes per instruction
         current_instruction = current_instruction + 2
-    
+
     assert c_lo == bitarray.util.ba2int(target.main_memory.memory[164])
     assert c_hi == bitarray.util.ba2int(target.main_memory.memory[165])
 
 
-
-@pytest.mark.parametrize(
-    ["a", "b"],
-a_b_pairs
-)
+@pytest.mark.parametrize(["a", "b"], a_b_pairs)
 def test_subroutine_two_byte_add_vals(a: int, b: int):
     prog_lines = load_sample_program("subroutine_two_byte_add.txt")
 
     assert a >= 0 and a < 2**16
     assert b >= 0 and b < 2**16
-    assert a+b < 2**26
+    assert a + b < 2**26
     # Calculate some bytes
     a_hi, a_lo = divmod(a, 256)
     b_hi, b_lo = divmod(b, 256)


### PR DESCRIPTION
Add another sample program which uses a proper subroutine to add two 2-byte numbers together. This has shown how fast one can run out of registers when trying to use 8-bit registers and 16-bit addresses.

Also have some tests of the new program.