### PR TITLE
Changing 'branch' to 'jump'

### DIFF
--- a/docs/functional_units.md
+++ b/docs/functional_units.md
@@ -30,7 +30,7 @@ write to A and B buses, and it will *only* do so during the Fetch0 and Fetch1 st
 During the PC Update pipeline stage, the Program Counter will increase its value by 2
 (wrapping), unless its 'increment enabled' flag is False.
 
-### Branch (PC BRANCH)
+### Jump (PC JUMP)
 
 This instruction unconditionally copies the contents of the A and B buses to the Program
 Counter, and sets the 'increment enabled' flag to False.

--- a/docs/functional_units.md
+++ b/docs/functional_units.md
@@ -36,32 +36,32 @@ This instruction unconditionally copies the contents of the A and B buses to the
 Counter, and sets the 'increment enabled' flag to False.
 This happens during the commit pipeline stage.
 
-### Branch If Zero (PC BRANCHZERO)
+### Jump If Zero (PC JUMPZERO)
 
 If all lines on C bus are zero, copy the contents of the A and B buses to the Program
 Counter and set the 'increment enabled' flag to False. If any of the C bus lines are
 non-zero, make no changes to the Program Counter, and leave 'increment enabled' as True.
 This happens during the commit pipeline stage.
 
-### Jump Subroutine (JSR)
+### Jump Subroutine (PC JSR)
 
 Combine A and B buses into an address. Copy the PC to the jump register, and the
 address from the buses into the PC. Inhibit incrementing.
 The PC to JR copy happens during the execute pipeline stage, and the PC update happens during
 the commit pipeline stage
 
-### Return (RET)
+### Return (PC RET)
 
 Copy the jump register to the PC.
 Do *not* inhibit incrementing.
 This happens during the commit pipeline stage.
 
-### Load Jump Register (LOADJUMP0/LOADJUMP1)
+### Load Jump Register (PC LOADJUMP0/LOADJUMP1)
 
 Put the low (0) or high (1) byte of the jump register on C bus.
 This happens during the execute pipeline stage.
 
-### Store Jump Register (STOREJUMP)
+### Store Jump Register (PC STOREJUMP)
 
 Combine A and B buses into an address, and store in the Jump Register.
 This happens during the commit pipeline stage.

--- a/docs/instructions.md
+++ b/docs/instructions.md
@@ -37,7 +37,7 @@ writes to A and B buses).
 
 | Instruction | `fff` | Operation | Registers  | Notes |
 |-------------|-------|-----------|------------|-------|
-| BRANCH      | `000` | `0000`    | `aaabbb000`|       |
+| JUMP        | `000` | `0000`    | `aaabbb000`|       |
 | JUMPZERO    | `000` | `1000`    | `aaabbbccc`| Register C is read      |
 | STOREJUMP   | `000` | `0100`    | `aaabbb000`|       |
 | JSR         | `000` | `1100`    | `aaabbb000`|       |

--- a/docs/instructions.md
+++ b/docs/instructions.md
@@ -38,7 +38,7 @@ writes to A and B buses).
 | Instruction | `fff` | Operation | Registers  | Notes |
 |-------------|-------|-----------|------------|-------|
 | BRANCH      | `000` | `0000`    | `aaabbb000`|       |
-| BRANCHZERO  | `000` | `1000`    | `aaabbbccc`| Register C is read      |
+| JUMPZERO    | `000` | `1000`    | `aaabbbccc`| Register C is read      |
 | STOREJUMP   | `000` | `0100`    | `aaabbb000`|       |
 | JSR         | `000` | `1100`    | `aaabbb000`|       |
 | RET         | `000` | `0010`    | `000000000`| Does not use main registers      |
@@ -49,7 +49,7 @@ Note that LOADJUMP0 and LOADJUMP1 are only a single bit different
 in their operation code.
 They also have the most significant bit of that operation
 code be a one, and all the others have a zero.
-Also note that the operation code for BRANCHZERO is the same
+Also note that the operation code for JUMPZERO is the same
 as that for MEM STORE below; both operations *read* from 
 register C.
 
@@ -64,7 +64,7 @@ register C.
 | STORE       | `100` | `1000`    | `aaabbbccc`| Register C is read      |
 
 Note that the operation code for STORE is the same as for
-PC BRANCHZERO.
+PC JUMPZERO.
 These are the two operations which *read* from register C.
 
 ## Registers (REG)

--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -38,7 +38,7 @@ appropriate bus.
 
 The appropriate execution unit will perform its task, placing
 its result on the appropriate bus.
-In the case of a branch instruction, the Program Counter's
+In the case of a jump instruction, the Program Counter's
 'increment enabled' flag will be marked as false.
 
 ## Commit
@@ -51,5 +51,5 @@ updated at this time.
 ## PC Update
 
 If the 'increment enabled' flag of the Program Counter is true
-(which it will be unless a branch has occurred), increment
+(which it will be unless a jump has occurred), increment
 the Program Counter by two.

--- a/emulator/sample_programs/count_by_five.txt
+++ b/emulator/sample_programs/count_by_five.txt
@@ -16,4 +16,4 @@
 10 MEM LOAD R1 R0 R3 # Load location 30 into R3
 12 DALU ADD R2 R3 R4 # R4 <- R2 + R3
 14 MEM STORE R1 R0 R4 # Save back to location 30
-16 PC BRANCH R7 R0
+16 PC JUMP R7 R0

--- a/emulator/sample_programs/incrementer.txt
+++ b/emulator/sample_programs/incrementer.txt
@@ -8,4 +8,4 @@
 
 # The loop
 6 SALU INC R0 R0  # Should be able to store back safely
-8 PC BRANCH R1 R2
+8 PC JUMP R1 R2

--- a/emulator/sample_programs/simple_two_byte_add.txt
+++ b/emulator/sample_programs/simple_two_byte_add.txt
@@ -83,7 +83,7 @@
 
 # Go into a loop to terminate
 76 REG SET078 R1
-78 PC BRANCH R1 R0  # Branch back to self
+78 PC JUMP R1 R0  # Branch back to self
 
 
 

--- a/emulator/sample_programs/simple_two_byte_add.txt
+++ b/emulator/sample_programs/simple_two_byte_add.txt
@@ -83,8 +83,4 @@
 
 # Go into a loop to terminate
 76 REG SET078 R1
-78 PC JUMP R1 R0  # Branch back to self
-
-
-
-
+78 PC JUMP R1 R0  # Jump back to self

--- a/emulator/sample_programs/simple_two_byte_add.txt
+++ b/emulator/sample_programs/simple_two_byte_add.txt
@@ -73,7 +73,7 @@
 # we need to increment
 62 REG SET000 R0
 64 REG SET070 R1 # First instruction past the INC
-66 PC BRANCHZERO R1 R0 R4  # Test the carry bit
+66 PC JUMPZERO R1 R0 R4  # Test the carry bit
 68 SALU INC R3 R3
 
 # Save out the high byte

--- a/emulator/sample_programs/subroutine_two_byte_add.txt
+++ b/emulator/sample_programs/subroutine_two_byte_add.txt
@@ -59,7 +59,7 @@
 34 REG SET038 R4 # Address of loop top
 36 REG SET052 R5 # Address of loop exit
 
-38 PC BRANCHZERO R5 R1 R3 # Start of the loop
+38 PC JUMPZERO R5 R1 R3 # Start of the loop
 
 40 MEM LOAD R0 R1 R2
 42 MEM STORE R6 R7 R2
@@ -141,7 +141,7 @@
 # we need to increment
 120 REG SET000 R0
 122 REG SET128 R1 # First instruction past the INC
-124 PC BRANCHZERO R1 R0 R4  # Test the carry bit
+124 PC JUMPZERO R1 R0 R4  # Test the carry bit
 126 SALU INC R3 R3
 
 # Save out the high byte

--- a/emulator/sample_programs/subroutine_two_byte_add.txt
+++ b/emulator/sample_programs/subroutine_two_byte_add.txt
@@ -66,7 +66,7 @@
 44 SALU INC R0 R0
 46 SALU INC R6 R6
 48 SALU DEC R3 R3
-50 PC BRANCH R4 R1 # End of loop body
+50 PC JUMP R4 R1 # End of loop body
 
 52 REG SET084 R0   # Point to start of the subroutine
 
@@ -93,7 +93,7 @@
 76 REG SET000 R2
 78 REG SET000 R6
 80 REG SET000 R7
-82 PC BRANCH R0 R1
+82 PC JUMP R0 R1
 
 # ----------
 

--- a/emulator/slothpu/_assembler.py
+++ b/emulator/slothpu/_assembler.py
@@ -47,7 +47,7 @@ def assemble_pc_instruction(parts: List[str]) -> bitarray.bitarray:
     R_A = 0
     R_B = 0
     R_C = 0
-    if operation == "BRANCH":
+    if operation == "JUMP":
         assert len(parts) == 5
         R_A = parse_register_part(parts[3])
         R_B = parse_register_part(parts[4])

--- a/emulator/slothpu/_assembler.py
+++ b/emulator/slothpu/_assembler.py
@@ -52,7 +52,7 @@ def assemble_pc_instruction(parts: List[str]) -> bitarray.bitarray:
         R_A = parse_register_part(parts[3])
         R_B = parse_register_part(parts[4])
         op_ba = bitarray.bitarray("0000", endian="little")
-    elif operation == "BRANCHZERO":
+    elif operation == "JUMPZERO":
         assert len(parts) == 6
         R_A = parse_register_part(parts[3])
         R_B = parse_register_part(parts[4])

--- a/emulator/slothpu/_program_counter.py
+++ b/emulator/slothpu/_program_counter.py
@@ -85,7 +85,7 @@ class ProgramCounter:
         commit_target = "PC"
 
         operations = {
-            0: "BRANCH",
+            0: "JUMP",
             1: "JUMPZERO",
             2: "STOREJUMP",
             3: "JSR",
@@ -100,7 +100,7 @@ class ProgramCounter:
         return op, commit_target
 
     def execute(self, command: str):
-        if command == "BRANCH":
+        if command == "JUMP":
             pass
         elif command == "JUMPZERO":
             pass
@@ -119,7 +119,7 @@ class ProgramCounter:
 
     def commit(self, command: str):
         jump_address = self._backplane.A_bus.value + self._backplane.B_bus.value
-        if command == "BRANCH":
+        if command == "JUMP":
             # Copy....
             self._set_pc(jump_address)
             self._increment_enable = False

--- a/emulator/slothpu/_program_counter.py
+++ b/emulator/slothpu/_program_counter.py
@@ -86,7 +86,7 @@ class ProgramCounter:
 
         operations = {
             0: "BRANCH",
-            1: "BRANCHZERO",
+            1: "JUMPZERO",
             2: "STOREJUMP",
             3: "JSR",
             4: "RET",
@@ -102,7 +102,7 @@ class ProgramCounter:
     def execute(self, command: str):
         if command == "BRANCH":
             pass
-        elif command == "BRANCHZERO":
+        elif command == "JUMPZERO":
             pass
         elif command == "STOREJUMP":
             pass
@@ -123,7 +123,7 @@ class ProgramCounter:
             # Copy....
             self._set_pc(jump_address)
             self._increment_enable = False
-        elif command == "BRANCHZERO":
+        elif command == "JUMPZERO":
             target = jump_address
             if bitarray.util.ba2int(self._backplane.C_bus.value) == 0:
                 self._set_pc(target)

--- a/emulator/test/test_e2e.py
+++ b/emulator/test/test_e2e.py
@@ -86,7 +86,7 @@ def test_increment_r0():
         )
         assert target.backplane.SALU_flag == (nxt_value % 256 == 0)
 
-    # Should end about to execute the branch again
+    # Should end about to execute the jump again
     assert bitarray.util.ba2int(target.program_counter.pc) == 8
 
 
@@ -189,14 +189,14 @@ def test_simple_two_byte_add():
     )
 
     # Now the advancing gets slightly difficult
-    # There's a branch zero about to go past
+    # There's a jump zero about to go past
     assert (a_lo + b_lo) >= 256, "Sanity check for carry"
 
     while current_instruction < 70:
         target.advance_instruction()
         # 2 bytes per instruction
         current_instruction = current_instruction + 2
-    # We should not have taken the branch, and hence
+    # We should not have taken the jump, and hence
     # we should have incremented R3
     assert (a_hi + b_hi + 1) % 256 == bitarray.util.ba2int(
         target.register_file.registers[3]

--- a/emulator/test/test_program_counter.py
+++ b/emulator/test/test_program_counter.py
@@ -129,13 +129,13 @@ def test_branch_if_zero():
 
     # Check that we do not branch and we leave incrementing enabled
     target._increment_enable = True
-    target.commit("BRANCHZERO")
+    target.commit("JUMPZERO")
     assert bitarray.util.ba2int(target.pc) == start_loc
     assert target.increment_enable is True
 
     # Now have C_bus be zero, see that we branch and disable incrementing
     bp.C_bus.value = bitarray.util.zeros(8, endian="little")
-    target.commit("BRANCHZERO")
+    target.commit("JUMPZERO")
     assert bitarray.util.ba2int(target.pc) == jump_loc
     assert target.increment_enable is False
     assert bitarray.util.ba2int(target.jr) == 0

--- a/emulator/test/test_program_counter.py
+++ b/emulator/test/test_program_counter.py
@@ -46,7 +46,7 @@ def test_fetch0():
     loc_ba = bitarray.util.int2ba(start_loc, target.n_bits, endian="little")
     bp.A_bus.value = loc_ba[0:8]
     bp.B_bus.value = loc_ba[8:16]
-    target.commit("BRANCH")
+    target.commit("JUMP")
     assert target.increment_enable is False  # Because we pushed a branch
 
     assert bitarray.util.ba2int(target.pc) == start_loc
@@ -73,7 +73,7 @@ def test_fetch1():
     loc_ba = bitarray.util.int2ba(start_loc, target.n_bits, endian="little")
     bp.A_bus.value = loc_ba[0:8]
     bp.B_bus.value = loc_ba[8:16]
-    target.commit("BRANCH")
+    target.commit("JUMP")
     assert target.increment_enable is not True
 
     assert bitarray.util.ba2int(target.pc) == start_loc
@@ -99,7 +99,7 @@ def test_branch():
     loc_ba = bitarray.util.int2ba(loc, target.n_bits, endian="little")
     bp.A_bus.value = loc_ba[0:8]
     bp.B_bus.value = loc_ba[8:16]
-    target.commit("BRANCH")
+    target.commit("JUMP")
     assert bitarray.util.ba2int(target.pc) == loc
     assert not target.increment_enable
     assert bitarray.util.ba2int(target.jr) == 0
@@ -116,7 +116,7 @@ def test_branch_if_zero():
     loc_ba = bitarray.util.int2ba(start_loc, target.n_bits, endian="little")
     bp.A_bus.value = loc_ba[0:8]
     bp.B_bus.value = loc_ba[8:16]
-    target.commit("BRANCH")
+    target.commit("JUMP")
     assert bitarray.util.ba2int(target.pc) == start_loc
 
     # Now set up A & B with the branch target
@@ -152,7 +152,7 @@ def test_jsr():
     loc_ba = bitarray.util.int2ba(start_loc, target.n_bits, endian="little")
     bp.A_bus.value = loc_ba[0:8]
     bp.B_bus.value = loc_ba[8:16]
-    target.commit("BRANCH")
+    target.commit("JUMP")
     assert bitarray.util.ba2int(target.pc) == start_loc
     assert bitarray.util.ba2int(target.jr) == 0
 
@@ -179,7 +179,7 @@ def test_ret():
     loc_ba = bitarray.util.int2ba(start_loc, target.n_bits, endian="little")
     bp.A_bus.value = loc_ba[0:8]
     bp.B_bus.value = loc_ba[8:16]
-    target.commit("BRANCH")
+    target.commit("JUMP")
     assert bitarray.util.ba2int(target.pc) == start_loc
     assert bitarray.util.ba2int(target.jr) == 0
 

--- a/emulator/test/test_program_counter.py
+++ b/emulator/test/test_program_counter.py
@@ -47,7 +47,7 @@ def test_fetch0():
     bp.A_bus.value = loc_ba[0:8]
     bp.B_bus.value = loc_ba[8:16]
     target.commit("JUMP")
-    assert target.increment_enable is False  # Because we pushed a branch
+    assert target.increment_enable is False  # Because we pushed a jump
 
     assert bitarray.util.ba2int(target.pc) == start_loc
 
@@ -87,7 +87,7 @@ def test_fetch1():
     assert bitarray.util.ba2int(target.jr) == 0
 
 
-def test_branch():
+def test_jump():
     bp = BackPlane(8)
     target = ProgramCounter(bp)
 
@@ -105,7 +105,7 @@ def test_branch():
     assert bitarray.util.ba2int(target.jr) == 0
 
 
-def test_branch_if_zero():
+def test_jump_if_zero():
     bp = BackPlane(8)
     target = ProgramCounter(bp)
 
@@ -119,7 +119,7 @@ def test_branch_if_zero():
     target.commit("JUMP")
     assert bitarray.util.ba2int(target.pc) == start_loc
 
-    # Now set up A & B with the branch target
+    # Now set up A & B with the jump target
     loc_ba = bitarray.util.int2ba(jump_loc, target.n_bits, endian="little")
     bp.A_bus.value = loc_ba[0:8]
     bp.B_bus.value = loc_ba[8:16]
@@ -127,13 +127,13 @@ def test_branch_if_zero():
     # Set up C bus to be non_zero
     bp.C_bus.value = bitarray.util.int2ba(2, length=bp.n_bits, endian="little")
 
-    # Check that we do not branch and we leave incrementing enabled
+    # Check that we do not jump and we leave incrementing enabled
     target._increment_enable = True
     target.commit("JUMPZERO")
     assert bitarray.util.ba2int(target.pc) == start_loc
     assert target.increment_enable is True
 
-    # Now have C_bus be zero, see that we branch and disable incrementing
+    # Now have C_bus be zero, see that we jump and disable incrementing
     bp.C_bus.value = bitarray.util.zeros(8, endian="little")
     target.commit("JUMPZERO")
     assert bitarray.util.ba2int(target.pc) == jump_loc
@@ -156,7 +156,7 @@ def test_jsr():
     assert bitarray.util.ba2int(target.pc) == start_loc
     assert bitarray.util.ba2int(target.jr) == 0
 
-    # Now set up A & B with the branch target
+    # Now set up A & B with the jump target
     loc_ba = bitarray.util.int2ba(subroutine_loc, target.n_bits, endian="little")
     bp.A_bus.value = loc_ba[0:8]
     bp.B_bus.value = loc_ba[8:16]


### PR DESCRIPTION
Starts to address #35 by renaming "branch' to 'jump' - everything we have so far as absolute changes to the PC, not relative ones.