### PR TITLE
Python tests for DALU

### DIFF
--- a/pcbs/python-testing/alu_connector_board.py
+++ b/pcbs/python-testing/alu_connector_board.py
@@ -1,4 +1,6 @@
-from typing import List
+from typing import Dict, List, Union
+
+import bitarray.util
 
 from tester_board import TesterBoard
 
@@ -10,22 +12,37 @@ class ALUConnectorBoard:
         # Enable all outputs
         self._tb.enable_outputs([True for _ in range(5)])
 
-    @property
-    def A_bus(self) -> List[int]:
-        return [31, 29, 27, 25, 23, 21, 19, 17]
+        # Set up the outputs; only have the Select line high
+        # (recall select is active-low)
+        self._outputs = [False for _ in range(self._tb.n_pins)]
+        self._outputs[self.Output_Pins["Select"]] = True
+        self.send()
+
+        # Read in the inputs
+        self._inputs = self._tb.recv()
 
     @property
-    def B_bus(self) -> List[int]:
-        return [15, 13, 11, 9, 7, 5, 3, 1]
+    def Output_Pins(self) -> Dict[str,Union[int, List[int]]]:
+        op = dict(
+            A_bus = [31, 29, 27, 25, 23, 21, 19, 17],
+            B_bus = [15, 13, 11, 9, 7, 5, 3, 1],
+            I = [33, 35, 37, 39],
+            Commit = 32,
+            Execute = 34,
+            Decode = 36,
+            Select = 38
+            )
+        return op
+        
 
-    @property
-    def I(self) -> List[int]:
-        return [33, 35, 37, 39]
+    def send(self):
+        self._tb.send(self._outputs)
 
-    @property
-    def Commit(self) -> int:
-        return 32
+    def A(self, value: int):
+        assert isinstance(value, int)
+        assert value > 0
+        assert value < 256
 
-    @property
-    def Execute(self) -> int:
-        return 34
+        converted = bitarray.util.int2ba(value, length=8, endian='little')
+        for i in range(8):
+            self._outputs[self.Output_Pins["A_bus"][i]] = converted[i]

--- a/pcbs/python-testing/alu_connector_board.py
+++ b/pcbs/python-testing/alu_connector_board.py
@@ -4,6 +4,7 @@ import bitarray.util
 
 from tester_board import TesterBoard
 
+
 class ALUConnectorBoard:
     def __init__(self):
         """Initialise with an internal TesterBoard."""
@@ -22,18 +23,17 @@ class ALUConnectorBoard:
         self._inputs = self._tb.recv()
 
     @property
-    def Output_Pins(self) -> Dict[str,Union[int, List[int]]]:
+    def Output_Pins(self) -> Dict[str, Union[int, List[int]]]:
         op = dict(
-            A_bus = [31, 29, 27, 25, 23, 21, 19, 17],
-            B_bus = [15, 13, 11, 9, 7, 5, 3, 1],
-            I = [33, 35, 37, 39],
-            Commit = 32,
-            Execute = 34,
-            Decode = 36,
-            Select = 38
-            )
+            A_bus=[31, 29, 27, 25, 23, 21, 19, 17],
+            B_bus=[15, 13, 11, 9, 7, 5, 3, 1],
+            I=[33, 35, 37, 39],
+            Commit=32,
+            Execute=34,
+            Decode=36,
+            Select=38,
+        )
         return op
-        
 
     def send(self):
         self._tb.send(self._outputs)
@@ -43,6 +43,6 @@ class ALUConnectorBoard:
         assert value > 0
         assert value < 256
 
-        converted = bitarray.util.int2ba(value, length=8, endian='little')
+        converted = bitarray.util.int2ba(value, length=8, endian="little")
         for i in range(8):
             self._outputs[self.Output_Pins["A_bus"][i]] = converted[i]

--- a/pcbs/python-testing/alu_connector_board.py
+++ b/pcbs/python-testing/alu_connector_board.py
@@ -116,25 +116,11 @@ class ALUConnectorBoard:
         for k, v in pins.items():
             self._outputs[self.Output_Pins[k]] = v
 
-    def Instruction(self, instr: str):
-        if instr == "ADD":
-            pins = [False, False, False, False]
-        elif instr == "SUB":
-            pins = [True, False, False, False]
-        elif instr == "OR":
-            pins = [False, False, True, False]
-        elif instr == "XOR":
-            pins = [True, False, True, False]
-        elif instr == "AND":
-            pins = [False, True, True, False]
-        elif instr == "NAND":
-            pins = [True, True, True, False]
-        else:
-            raise ValueError(f"Bad instruction: {instr}")
-        assert len(pins) == 4
+    def Instruction(self, instructions: List[bool]):
+        assert len(instructions) == 4
 
-        for i in range(len(pins)):
-            self._outputs[self.Output_Pins["I"][i]] = pins[i]
+        for i in range(len(instructions)):
+            self._outputs[self.Output_Pins["I"][i]] = instructions[i]
 
     def C(self) -> int:
         C_pins = self.Input_Pins["C_bus"]

--- a/pcbs/python-testing/alu_connector_board.py
+++ b/pcbs/python-testing/alu_connector_board.py
@@ -123,6 +123,7 @@ class ALUConnectorBoard:
             self._outputs[self.Output_Pins["I"][i]] = instructions[i]
 
     def C(self) -> int:
+        print(f"All Inputs: {self._inputs}")
         C_pins = self.Input_Pins["C_bus"]
         C_vals = []
         for p in C_pins:

--- a/pcbs/python-testing/alu_connector_board.py
+++ b/pcbs/python-testing/alu_connector_board.py
@@ -123,7 +123,6 @@ class ALUConnectorBoard:
             self._outputs[self.Output_Pins["I"][i]] = instructions[i]
 
     def C(self) -> int:
-        print(f"All Inputs: {self._inputs}")
         C_pins = self.Input_Pins["C_bus"]
         C_vals = []
         for p in C_pins:

--- a/pcbs/python-testing/alu_connector_board.py
+++ b/pcbs/python-testing/alu_connector_board.py
@@ -52,3 +52,49 @@ class ALUConnectorBoard:
 
     def B(self, value: int):
         self._set_output_bus(value, "B_bus")
+
+
+    def Select(self, value: bool):
+        self._outputs[self.Output_Pins["Select"]] = value
+        
+    def Phase(self, phase: str):
+        pins = dict(
+            Commit = False,
+            Execute = False,
+            Decode = False
+        )
+        if phase == "Other":
+            pass
+        elif phase == "Decode":
+            pins["Decode"] = True
+        elif phase == "Execute":
+            pins["Execute"] = True
+        elif phase == "Commit":
+            pins["Commit"] = True
+        else:
+            raise ValueError(f"Bad phase: {phase}")
+
+        # Set the output pins
+        for k, v in pins.items():
+            self._outputs[self.Output_Pins[k]] = v
+        
+
+    def Instruction(self, instr: str):
+        if instr == "ADD":
+            pins = [False, False, False, False]
+        elif instr == "SUB":
+            pins = [True, False, False, False]
+        elif instr == "OR":
+            pins = [False, False, True, False]
+        elif instr == "XOR":
+            pins = [True, False, True, False]
+        elif instr == "AND":
+            pins = [False, True, True, False]
+        elif instr == "NAND":
+            pins = [True, True, True, False]
+        else:
+            raise ValueError(f"Bad instruction: {instr}")
+        assert len(pins) == 4
+
+        for i in range(len(pins)):
+            self._outputs[self.Output_Pins["I"][i]] = pins[i]

--- a/pcbs/python-testing/alu_connector_board.py
+++ b/pcbs/python-testing/alu_connector_board.py
@@ -39,7 +39,7 @@ class ALUConnectorBoard:
     def Input_Pins(self) -> Dict[str, Union[int, List[int]]]:
         ip = dict(
             C_bus=[0, 1, 2, 3, 4, 5, 6, 7],
-            DALU_Flag=8,
+            ALU_Flag=8,
             In=[
                 19,
                 18,
@@ -131,8 +131,8 @@ class ALUConnectorBoard:
         value = bitarray.util.ba2int(bitarray.bitarray(C_vals, endian="little"))
         return value
 
-    def DALU_Flag(self) -> bool:
-        return self._inputs[self.Input_Pins["DALU_Flag"]]
+    def ALU_Flag(self) -> bool:
+        return self._inputs[self.Input_Pins["ALU_Flag"]]
 
     def Inputs(self) -> List[int]:
         result = []

--- a/pcbs/python-testing/alu_connector_board.py
+++ b/pcbs/python-testing/alu_connector_board.py
@@ -77,7 +77,7 @@ class ALUConnectorBoard:
 
     def recv(self):
         self._inputs = self._tb.recv()
-    
+
     def send(self):
         self._tb.send(self._outputs)
 
@@ -144,3 +144,13 @@ class ALUConnectorBoard:
 
         value = bitarray.util.ba2int(bitarray.bitarray(C_vals, endian="little"))
         return value
+
+    def DALU_Flag(self) -> bool:
+        return self._inputs[self.Input_Pins["DALU_Flag"]]
+
+    def Inputs(self) -> List[int]:
+        result = []
+        for p in self.Input_Pins["In"]:
+            result.append(self._inputs[p])
+        assert len(result) == 30
+        return result

--- a/pcbs/python-testing/alu_connector_board.py
+++ b/pcbs/python-testing/alu_connector_board.py
@@ -38,11 +38,17 @@ class ALUConnectorBoard:
     def send(self):
         self._tb.send(self._outputs)
 
-    def A(self, value: int):
+    def _set_output_bus(self, value: int, bus_name: str):
         assert isinstance(value, int)
-        assert value > 0
+        assert value >= 0
         assert value < 256
 
         converted = bitarray.util.int2ba(value, length=8, endian="little")
         for i in range(8):
-            self._outputs[self.Output_Pins["A_bus"][i]] = converted[i]
+            self._outputs[self.Output_Pins[bus_name][i]] = converted[i]
+
+    def A(self, value: int):
+        self._set_output_bus(value, "A_bus")
+
+    def B(self, value: int):
+        self._set_output_bus(value, "B_bus")

--- a/pcbs/python-testing/alu_connector_board.py
+++ b/pcbs/python-testing/alu_connector_board.py
@@ -1,0 +1,31 @@
+from typing import List
+
+from tester_board import TesterBoard
+
+class ALUConnectorBoard:
+    def __init__(self):
+        """Initialise with an internal TesterBoard."""
+        self._tb = TesterBoard()
+
+        # Enable all outputs
+        self._tb.enable_outputs([True for _ in range(5)])
+
+    @property
+    def A_bus(self) -> List[int]:
+        return [31, 29, 27, 25, 23, 21, 19, 17]
+
+    @property
+    def B_bus(self) -> List[int]:
+        return [15, 13, 11, 9, 7, 5, 3, 1]
+
+    @property
+    def I(self) -> List[int]:
+        return [33, 35, 37, 39]
+
+    @property
+    def Commit(self) -> int:
+        return 32
+
+    @property
+    def Execute(self) -> int:
+        return 34

--- a/pcbs/python-testing/alu_connector_board.py
+++ b/pcbs/python-testing/alu_connector_board.py
@@ -20,7 +20,7 @@ class ALUConnectorBoard:
         self.send()
 
         # Read in the inputs
-        self._inputs = self._tb.recv()
+        self.recv()
 
     @property
     def Output_Pins(self) -> Dict[str, Union[int, List[int]]]:
@@ -35,6 +35,49 @@ class ALUConnectorBoard:
         )
         return op
 
+    @property
+    def Input_Pins(self) -> Dict[str, Union[int, List[int]]]:
+        ip = dict(
+            C_bus=[0, 1, 2, 3, 4, 5, 6, 7],
+            DALU_Flag=8,
+            In=[
+                19,
+                18,
+                17,
+                16,
+                15,
+                14,
+                12,
+                13,
+                10,
+                11,  # End of Set 0
+                29,
+                28,
+                27,
+                26,
+                25,
+                24,
+                22,
+                23,
+                20,
+                21,  # End of Set 1
+                39,
+                38,
+                37,
+                36,
+                35,
+                34,
+                32,
+                33,
+                30,
+                31,  # End of Set 2
+            ],
+        )
+        return ip
+
+    def recv(self):
+        self._inputs = self._tb.recv()
+    
     def send(self):
         self._tb.send(self._outputs)
 
@@ -92,3 +135,12 @@ class ALUConnectorBoard:
 
         for i in range(len(pins)):
             self._outputs[self.Output_Pins["I"][i]] = pins[i]
+
+    def C(self) -> int:
+        C_pins = self.Input_Pins["C_bus"]
+        C_vals = []
+        for p in C_pins:
+            C_vals.append(self._inputs[p])
+
+        value = bitarray.util.ba2int(bitarray.bitarray(C_vals, endian="little"))
+        return value

--- a/pcbs/python-testing/alu_connector_board.py
+++ b/pcbs/python-testing/alu_connector_board.py
@@ -53,16 +53,11 @@ class ALUConnectorBoard:
     def B(self, value: int):
         self._set_output_bus(value, "B_bus")
 
-
     def Select(self, value: bool):
         self._outputs[self.Output_Pins["Select"]] = value
-        
+
     def Phase(self, phase: str):
-        pins = dict(
-            Commit = False,
-            Execute = False,
-            Decode = False
-        )
+        pins = dict(Commit=False, Execute=False, Decode=False)
         if phase == "Other":
             pass
         elif phase == "Decode":
@@ -77,7 +72,6 @@ class ALUConnectorBoard:
         # Set the output pins
         for k, v in pins.items():
             self._outputs[self.Output_Pins[k]] = v
-        
 
     def Instruction(self, instr: str):
         if instr == "ADD":

--- a/pcbs/python-testing/test_dalu_board.py
+++ b/pcbs/python-testing/test_dalu_board.py
@@ -41,7 +41,7 @@ class TestDecoder:
         acb.recv()
         inputs = acb.Inputs()
         for k, v in input_decoder.items():
-            assert inputs[v] == True, f"Checking {k}"
+            assert inputs[v], f"Checking {k}"
 
         # Now set an instruction
         acb.Instruction(instructions[current_instruction])
@@ -51,7 +51,7 @@ class TestDecoder:
         acb.recv()
         inputs = acb.Inputs()
         for k, v in input_decoder.items():
-            assert inputs[v] == True, f"Checking {k}"
+            assert inputs[v], f"Checking {k}"
 
         # Now set select
         acb.Select(False)
@@ -70,4 +70,4 @@ class TestDecoder:
         acb.recv()
         inputs = acb.Inputs()
         for k, v in input_decoder.items():
-            assert inputs[v] == True, f"Checking {k}"
+            assert inputs[v], f"Checking {k}"

--- a/pcbs/python-testing/test_dalu_board.py
+++ b/pcbs/python-testing/test_dalu_board.py
@@ -1,4 +1,3 @@
-from time import sleep
 from typing import List
 
 import bitarray.util
@@ -62,12 +61,12 @@ test_values = [
 ]
 
 
-def result_from_input(input: List[bool]):
-    assert len(input) == 30
+def result_from_input(input_pins: List[bool]):
+    assert len(input_pins) == 30
 
     result_bits = []
     for p in input_decoder["RESULT"]:
-        result_bits.append(input[p])
+        result_bits.append(input_pins[p])
 
     value = bitarray.util.ba2int(bitarray.bitarray(result_bits, endian="little"))
     return value
@@ -120,7 +119,7 @@ class TestDecoder:
                 assert inputs[v], f"Checking {k}"
 
 
-class TestAND:
+class TestBitwiseOperations:
     def compute_expected(self, A: int, B: int, operation: str):
         assert A >= 0 and A < 256
         assert B >= 0 and B < 256
@@ -152,7 +151,7 @@ class TestAND:
 
         acb.recv()
         inputs = acb.Inputs()
-        assert inputs[input_decoder["FLAG"]] == False
+        assert not inputs[input_decoder["FLAG"]]
         result = result_from_input(inputs)
         assert result == C_expected
 
@@ -160,17 +159,17 @@ class TestAND:
         acb.send()
         acb.recv()
         inputs = acb.Inputs()
-        assert inputs[input_decoder["FLAG"]] == False
+        assert not inputs[input_decoder["FLAG"]]
         result = result_from_input(inputs)
         assert result == C_expected
         assert acb.C() == C_expected
-        assert acb.ALU_Flag() == False
+        assert not acb.ALU_Flag()
 
         acb.Phase("Commit")
         acb.send()
         acb.recv()
         assert acb.C() == C_expected
-        assert acb.ALU_Flag() == False
+        assert not acb.ALU_Flag()
 
     @pytest.mark.parametrize("A", test_values)
     @pytest.mark.parametrize("B", test_values)
@@ -197,7 +196,7 @@ class TestAND:
         # Retrieve the internal state
         acb.recv()
         inputs = acb.Inputs()
-        assert inputs[input_decoder["FLAG"]] == False
+        assert not inputs[input_decoder["FLAG"]]
         result = result_from_input(inputs)
         assert result == expected_C
 

--- a/pcbs/python-testing/test_dalu_board.py
+++ b/pcbs/python-testing/test_dalu_board.py
@@ -8,9 +8,14 @@ instructions_rev1 = dict(
     SUB=[False, True, True, False],
     OR=[True, True, False, False],
     XOR=[False, True, False, False],
-    AND=[True, False, False, False,],
+    AND=[
+        True,
+        False,
+        False,
+        False,
+    ],
     NAND=[False, False, False, False],
-    )
+)
 
 input_decoder_rev1 = dict(
     ADD=29,
@@ -21,12 +26,14 @@ input_decoder_rev1 = dict(
     NAND=24,
 )
 
-instructions=instructions_rev1
-input_decoder=input_decoder_rev1
+instructions = instructions_rev1
+input_decoder = input_decoder_rev1
 
 
 class TestDecoder:
-    @pytest.mark.parametrize("current_instruction", ["ADD", "SUB", "OR", "XOR", "AND", "NAND"])
+    @pytest.mark.parametrize(
+        "current_instruction", ["ADD", "SUB", "OR", "XOR", "AND", "NAND"]
+    )
     def test_instruction_decode(self, current_instruction):
         acb = ALUConnectorBoard()
 
@@ -64,4 +71,3 @@ class TestDecoder:
         inputs = acb.Inputs()
         for k, v in input_decoder.items():
             assert inputs[v] == True, f"Checking {k}"
-        

--- a/pcbs/python-testing/test_dalu_board.py
+++ b/pcbs/python-testing/test_dalu_board.py
@@ -127,13 +127,17 @@ class TestBitwiseOperations:
             result = A & B
         elif operation == "NAND":
             result = ~(A & B)
+        elif operation == "OR":
+            result = A | B
+        elif operation == "XOR":
+            result = A ^ B
         else:
             raise ValueError(f"Unrecognised operation: {operation}")
         if result < 0:
             result = result + 256
         return result
 
-    @pytest.mark.parametrize("operation", ["AND", "NAND"])
+    @pytest.mark.parametrize("operation", ["AND", "NAND", "OR", "XOR"])
     def test_smoke(self, operation):
         acb = ALUConnectorBoard()
 
@@ -173,7 +177,7 @@ class TestBitwiseOperations:
 
     @pytest.mark.parametrize("A", test_values)
     @pytest.mark.parametrize("B", test_values)
-    @pytest.mark.parametrize("operation", ["AND", "NAND"])
+    @pytest.mark.parametrize("operation", ["AND", "NAND", "OR", "XOR"])
     def test_specific_values(self, A, B, operation):
         acb = ALUConnectorBoard()
 

--- a/pcbs/python-testing/test_dalu_board.py
+++ b/pcbs/python-testing/test_dalu_board.py
@@ -187,6 +187,12 @@ class TestOperations:
         assert acb.C() == C_expected
         assert acb.ALU_Flag() == flag_expected
 
+        acb.Phase("Other")
+        acb.send()
+        acb.recv()
+        assert acb.C() == 0
+        assert acb.ALU_Flag() == flag_expected
+
     @pytest.mark.parametrize("A", test_values)
     @pytest.mark.parametrize("B", test_values)
     @pytest.mark.parametrize("operation", ["AND", "NAND", "OR", "XOR", "ADD", "SUB"])
@@ -232,4 +238,13 @@ class TestOperations:
         # Check that the answer is still available
         acb.recv()
         assert acb.C() == expected_C
+        assert acb.ALU_Flag() == expected_flag
+
+        # Check that going to another phase puts
+        # the C bus into high impedance (which is
+        # pulled down on the Tester board itself)
+        acb.Phase("Other")
+        acb.send()
+        acb.recv()
+        assert acb.C() == 0
         assert acb.ALU_Flag() == expected_flag

--- a/pcbs/python-testing/test_dalu_board.py
+++ b/pcbs/python-testing/test_dalu_board.py
@@ -115,7 +115,6 @@ class TestAND:
         result = result_from_input(inputs)
         assert result == A_val & B_val
 
-        sleep(20)
 
         acb.Phase("Execute")
         acb.send()
@@ -125,10 +124,10 @@ class TestAND:
         result = result_from_input(inputs)
         assert result == A_val & B_val
         assert acb.C() == A_val & B_val
-        assert acb.Flag() == False
+        assert acb.ALU_Flag() == False
 
         acb.Phase("Commit")
         acb.send()
         acb.recv()
         assert acb.C() == A_val & B_val
-        assert acb.Flag() == False
+        assert acb.ALU_Flag() == False

--- a/pcbs/python-testing/test_dalu_board.py
+++ b/pcbs/python-testing/test_dalu_board.py
@@ -35,6 +35,22 @@ input_decoder_rev1 = dict(
 instructions = instructions_rev1
 input_decoder = input_decoder_rev1
 
+# =======================================
+
+a_b_pairs = [
+    (0, 0),
+    (1, 0),
+    (0, 1),
+    (128, 128),
+    (255, 1),
+    (1, 255),
+    (137, 2),
+    (101, 13),
+    (7, 240),
+    (8, 240),
+    (240, 8),
+    (255, 255),
+]
 
 def result_from_input(input: List[bool]):
     assert len(input) == 30
@@ -131,3 +147,48 @@ class TestAND:
         acb.recv()
         assert acb.C() == A_val & B_val
         assert acb.ALU_Flag() == False
+
+    @pytest.mark.parametrize(["A", "B"], a_b_pairs)
+    def test_specific_values(self, A, B):
+        acb = ALUConnectorBoard()
+
+        expected_C = A & B
+        
+        # Initally, C should be zero since the select
+        # line will be high
+        acb.recv()
+        assert acb.C() == 0
+
+        # Now send the inputs, select the instruction
+        # enable the DALU and set to decode
+        acb.A(A)
+        acb.B(B)
+        acb.Instruction(instructions["AND"])
+        acb.Select(False)
+        acb.Phase("Decode")
+        acb.send()
+
+        # Retrieve the internal state
+        acb.recv()
+        inputs = acb.Inputs()
+        assert inputs[input_decoder["FLAG"]] == False
+        result = result_from_input(inputs)
+        assert result == expected_C
+
+        # Go to the execute phase
+        acb.Phase("Execute")
+        acb.send()
+
+        # Check that answer is now externally visible
+        acb.recv()
+        assert acb.C() == expected_C
+        assert not acb.ALU_Flag(), "Check ALU_flag cleared"
+
+        # Go to the commit phase
+        acb.Phase("Commit")
+        acb.send()
+
+        # Check that the answer is still available
+        acb.recv()
+        assert acb.C() == expected_C
+        assert not acb.ALU_Flag(), "Check ALU_flag cleared"

--- a/pcbs/python-testing/test_dalu_board.py
+++ b/pcbs/python-testing/test_dalu_board.py
@@ -37,21 +37,30 @@ input_decoder = input_decoder_rev1
 
 # =======================================
 
-a_b_pairs = [
-    (0, 0),
-    (1, 0),
-    (0, 1),
-    (128, 128),
-    (255, 1),
-    (1, 255),
-    (137, 2),
-    (101, 13),
-    (7, 240),
-    (8, 240),
-    (240, 8),
-    (255, 255),
+
+test_values = [
+    0,
+    1,
+    2,
+    3,
+    4,
+    8,
+    16,
+    31,
+    32,
+    33,
+    64,
+    127,
+    128,
+    129,
+    250,
+    251,
+    252,
+    253,
+    254,
+    255,
 ]
-test_values = [0,1,2,31,32,33,127,128,129,250,251,252,253,254,255]
+
 
 def result_from_input(input: List[bool]):
     assert len(input) == 30
@@ -112,13 +121,13 @@ class TestDecoder:
 
 
 class TestAND:
-    def compute_expected(self, A: int, B:int, operation:str):
-        assert A >= 0 and A<256
-        assert B >=0 and B<256
-        if operation== "AND":
+    def compute_expected(self, A: int, B: int, operation: str):
+        assert A >= 0 and A < 256
+        assert B >= 0 and B < 256
+        if operation == "AND":
             result = A & B
-        elif operation=="NAND":
-            result = ~(A&B)
+        elif operation == "NAND":
+            result = ~(A & B)
         else:
             raise ValueError(f"Unrecognised operation: {operation}")
         if result < 0:
@@ -132,7 +141,7 @@ class TestAND:
         A_val = 6
         B_val = 130
         C_expected = self.compute_expected(A_val, B_val, operation)
-        
+
         acb.A(A_val)
         acb.B(B_val)
         acb.Instruction(instructions[operation])
@@ -146,7 +155,6 @@ class TestAND:
         assert inputs[input_decoder["FLAG"]] == False
         result = result_from_input(inputs)
         assert result == C_expected
-
 
         acb.Phase("Execute")
         acb.send()
@@ -171,7 +179,7 @@ class TestAND:
         acb = ALUConnectorBoard()
 
         expected_C = self.compute_expected(A, B, operation)
-        
+
         # Initally, C should be zero since the select
         # line will be high
         acb.recv()

--- a/pcbs/python-testing/test_dalu_board.py
+++ b/pcbs/python-testing/test_dalu_board.py
@@ -1,3 +1,7 @@
+from time import sleep
+from typing import List
+
+import bitarray.util
 import pytest
 
 from alu_connector_board import ALUConnectorBoard
@@ -24,11 +28,22 @@ input_decoder_rev1 = dict(
     XOR=26,
     AND=25,
     NAND=24,
+    FLAG=9,
+    RESULT=[1,2,3,4,5,6,7,8]
 )
 
 instructions = instructions_rev1
 input_decoder = input_decoder_rev1
 
+def result_from_input(input: List[bool]):
+    assert len(input)==30
+
+    result_bits = []
+    for p in input_decoder["RESULT"]:
+        result_bits.append(input[p])
+
+    value = bitarray.util.ba2int(bitarray.bitarray(result_bits, endian="little"))
+    return value
 
 class TestDecoder:
     @pytest.mark.parametrize(
@@ -41,7 +56,8 @@ class TestDecoder:
         acb.recv()
         inputs = acb.Inputs()
         for k, v in input_decoder.items():
-            assert inputs[v], f"Checking {k}"
+            if k in instructions.keys():
+                assert inputs[v], f"Checking {k}"
 
         # Now set an instruction
         acb.Instruction(instructions[current_instruction])
@@ -51,7 +67,8 @@ class TestDecoder:
         acb.recv()
         inputs = acb.Inputs()
         for k, v in input_decoder.items():
-            assert inputs[v], f"Checking {k}"
+            if k in instructions.keys():
+                assert inputs[v], f"Checking {k}"
 
         # Now set select
         acb.Select(False)
@@ -61,7 +78,8 @@ class TestDecoder:
         acb.recv()
         inputs = acb.Inputs()
         for k, v in input_decoder.items():
-            assert inputs[v] == (k != current_instruction), f"Checking {k}"
+            if k in instructions.keys():
+                assert inputs[v] == (k != current_instruction), f"Checking {k}"
 
         # And deselect again
         acb.Select(True)
@@ -70,4 +88,46 @@ class TestDecoder:
         acb.recv()
         inputs = acb.Inputs()
         for k, v in input_decoder.items():
-            assert inputs[v], f"Checking {k}"
+            if k in instructions.keys():
+                assert inputs[v], f"Checking {k}"
+
+class TestAND:
+    def test_smoke(self):
+        acb = ALUConnectorBoard()
+
+        A_val = 6
+        B_val = 130
+
+        acb.A(A_val)
+        acb.B(B_val)
+        acb.Instruction(instructions["AND"])
+        acb.Select(False)
+        acb.Phase("Decode")
+
+        acb.send()
+
+        acb.recv()
+        inputs = acb.Inputs()
+        assert inputs[input_decoder["FLAG"]] == False
+        result = result_from_input(inputs)
+        assert result == A_val & B_val
+
+        sleep(20)
+        
+        acb.Phase("Execute")
+        acb.send()
+        acb.recv()
+        inputs = acb.Inputs()
+        assert inputs[input_decoder["FLAG"]] == False
+        result = result_from_input(inputs)
+        assert result == A_val & B_val
+        assert acb.C() == A_val & B_val
+        assert acb.Flag() == False
+
+        acb.Phase("Commit")
+        acb.send()
+        acb.recv()
+        assert acb.C() == A_val & B_val
+        assert acb.Flag() == False
+        
+        

--- a/pcbs/python-testing/test_dalu_board.py
+++ b/pcbs/python-testing/test_dalu_board.py
@@ -29,14 +29,15 @@ input_decoder_rev1 = dict(
     AND=25,
     NAND=24,
     FLAG=9,
-    RESULT=[1,2,3,4,5,6,7,8]
+    RESULT=[1, 2, 3, 4, 5, 6, 7, 8],
 )
 
 instructions = instructions_rev1
 input_decoder = input_decoder_rev1
 
+
 def result_from_input(input: List[bool]):
-    assert len(input)==30
+    assert len(input) == 30
 
     result_bits = []
     for p in input_decoder["RESULT"]:
@@ -44,6 +45,7 @@ def result_from_input(input: List[bool]):
 
     value = bitarray.util.ba2int(bitarray.bitarray(result_bits, endian="little"))
     return value
+
 
 class TestDecoder:
     @pytest.mark.parametrize(
@@ -91,6 +93,7 @@ class TestDecoder:
             if k in instructions.keys():
                 assert inputs[v], f"Checking {k}"
 
+
 class TestAND:
     def test_smoke(self):
         acb = ALUConnectorBoard()
@@ -113,7 +116,7 @@ class TestAND:
         assert result == A_val & B_val
 
         sleep(20)
-        
+
         acb.Phase("Execute")
         acb.send()
         acb.recv()
@@ -129,5 +132,3 @@ class TestAND:
         acb.recv()
         assert acb.C() == A_val & B_val
         assert acb.Flag() == False
-        
-        

--- a/pcbs/python-testing/test_dalu_board.py
+++ b/pcbs/python-testing/test_dalu_board.py
@@ -50,7 +50,18 @@ class TestDecoder:
         acb.Select(False)
         acb.send()
 
+        # We should be able to detect the instruction
         acb.recv()
         inputs = acb.Inputs()
         for k, v in input_decoder.items():
             assert inputs[v] == (k != current_instruction), f"Checking {k}"
+
+        # And deselect again
+        acb.Select(True)
+        acb.send()
+
+        acb.recv()
+        inputs = acb.Inputs()
+        for k, v in input_decoder.items():
+            assert inputs[v] == True, f"Checking {k}"
+        

--- a/pcbs/python-testing/test_dalu_board.py
+++ b/pcbs/python-testing/test_dalu_board.py
@@ -1,0 +1,56 @@
+import pytest
+
+from alu_connector_board import ALUConnectorBoard
+
+# Rev1 board has decoder outputs backwards
+instructions_rev1 = dict(
+    ADD=[True, True, True, False],
+    SUB=[False, True, True, False],
+    OR=[True, True, False, False],
+    XOR=[False, True, False, False],
+    AND=[True, False, False, False,],
+    NAND=[False, False, False, False],
+    )
+
+input_decoder_rev1 = dict(
+    ADD=29,
+    SUB=28,
+    OR=27,
+    XOR=26,
+    AND=25,
+    NAND=24,
+)
+
+instructions=instructions_rev1
+input_decoder=input_decoder_rev1
+
+
+class TestDecoder:
+    @pytest.mark.parametrize("current_instruction", ["ADD", "SUB", "OR", "XOR", "AND", "NAND"])
+    def test_instruction_decode(self, current_instruction):
+        acb = ALUConnectorBoard()
+
+        # On initialisation, all selectors should be high
+        acb.recv()
+        inputs = acb.Inputs()
+        for k, v in input_decoder.items():
+            assert inputs[v] == True, f"Checking {k}"
+
+        # Now set an instruction
+        acb.Instruction(instructions[current_instruction])
+        acb.send()
+
+        # However, nothing should have changed yet
+        acb.recv()
+        inputs = acb.Inputs()
+        for k, v in input_decoder.items():
+            assert inputs[v] == True, f"Checking {k}"
+
+        # Now set select
+        acb.Select(False)
+        acb.send()
+
+        acb.recv()
+        inputs = acb.Inputs()
+        for k, v in input_decoder.items():
+            assert inputs[v] == (k != current_instruction), f"Checking {k}"

--- a/pcbs/python-testing/test_dalu_board.py
+++ b/pcbs/python-testing/test_dalu_board.py
@@ -124,7 +124,7 @@ class TestOperations:
         assert A >= 0 and A < 256
         assert B >= 0 and B < 256
         flag = False
-        
+
         if operation == "AND":
             result = A & B
         elif operation == "NAND":
@@ -135,18 +135,18 @@ class TestOperations:
             result = A ^ B
         elif operation == "ADD":
             result = A + B
-            flag = (result >= 256)
+            flag = result >= 256
         elif operation == "SUB":
             result = A - B
-            flag = (result < 0)
+            flag = result < 0
         else:
             raise ValueError(f"Unrecognised operation: {operation}")
-        
+
         if result < 0:
             result = result + 256
         if result >= 256:
             result = result - 256
-            
+
         return result, flag
 
     @pytest.mark.parametrize("operation", ["AND", "NAND", "OR", "XOR", "ADD", "SUB"])
@@ -155,7 +155,7 @@ class TestOperations:
 
         A_val = 6
         B_val = 130
-        C_expected,flag_expected = self.compute_expected(A_val, B_val, operation)
+        C_expected, flag_expected = self.compute_expected(A_val, B_val, operation)
 
         acb.A(A_val)
         acb.B(B_val)


### PR DESCRIPTION
Adding tests for the DALU board which can run with `pytest`. Note that these are for the r1 board, which has the instruction decoder outputs connected backwards.