### PR TITLE
Tester for the Register File

### DIFF
--- a/pcbs/Register File/selectors.kicad_sch
+++ b/pcbs/Register File/selectors.kicad_sch
@@ -2573,6 +2573,12 @@
     (uuid fe59cbd8-de0c-4977-bf89-39a03c9af2d3)
   )
 
+  (text "This is a mistaken connection. The register\nupdate is supposed to happen on Commit, not\non Execute."
+    (at 71.12 151.13 0)
+    (effects (font (size 1.27 1.27)) (justify left bottom))
+    (uuid 3fe90495-857b-454e-9c05-84bf8738714e)
+  )
+
   (label "R_{C}0" (at 31.75 63.5 0) (fields_autoplaced)
     (effects (font (size 1.27 1.27)) (justify left bottom))
     (uuid 043bbbe3-d84c-4824-99bf-1469cb4d3382)

--- a/pcbs/python-testing/register_file_connector_board.py
+++ b/pcbs/python-testing/register_file_connector_board.py
@@ -1,0 +1,137 @@
+from typing import Dict, List, Union
+
+import bitarray.util
+
+from tester_board import TesterBoard
+
+
+class RegisterFileConnectorBoard:
+    def __init__(self):
+        """Initialise with an internal Testerboard."""
+        self._tb = TesterBoard()
+
+        # Start with all outputs disabled
+        # This is safer since we read and write from C bus
+        self._tb.enable_outputs([False for _ in range(5)])
+
+        # Now set up the outputs
+        # Most low, but set the 'C_write_read' pin high
+        self._outputs = [False for _ in range(self._tb.n_pins)]
+        self._outputs[self.Output_Pins["C_write_read"]] = True
+        self.send()
+        self._tb.enable_outputs([True for _ in range(5)])
+
+        # Read in the inputs
+        self.recv()
+
+    @property
+    def Output_Pins(self) -> Dict[str, Union[int, List[int]]]:
+        op = dict(
+            C_bus=[7, 6, 5, 4, 3, 2, 1, 0],
+            C_write_read=9,
+            R_A=[11, 13, 15],
+            R_B=[17, 19, 21],
+            R_C=[23, 25, 27],
+            Commit=37,
+            Execute=38,
+            Decode=36,
+            PCUpdate=39,
+        )
+        return op
+
+    @property
+    def Input_Pins(self) -> Dict[str, Union[int, List[int]]]:
+        ip = dict(
+            A_bus=[1, 3, 5, 7, 9, 11, 13, 15],
+            B_bus=[17, 19, 21, 23, 25, 27, 29, 31],
+            C_bus=[0, 2, 4, 6, 8, 10, 12, 14],
+        )
+        return ip
+
+    def recv(self):
+        self._inputs = self._tb.recv()
+
+    def send(self):
+        self._tb.send(self._outputs)
+
+    def _set_output_bus(self, value: int, bus_name: str):
+        assert isinstance(value, int)
+        assert value >= 0
+        assert value < 256
+
+        converted = bitarray.util.int2ba(value, length=8, endian="little")
+        for i in range(8):
+            self._outputs[self.Output_Pins[bus_name][i]] = converted[i]
+
+
+    def C_bus_write(self, value: int):
+        self._set_output_bus(value, "C_bus")
+
+    def C_write_read(self, value: bool):
+        if value:
+            # Going to write to C_bus, need to enable output
+            self._tb.enable_output([True, True, True, True, True])
+        else:
+            # We're reading, so need to disable the output pins for
+            # C_bus
+            self._tb.enable_output([False, True, True, True, True])
+        self._outputs[self.Output_Pins["C_write_read"]] = value
+
+
+    def Phase(self, phase: str):
+        pins = dict(Commit=False, Execute=False, Decode=False, PCUpdate=False)
+        if phase == "Other":
+            pass
+        elif phase == "Decode":
+            pins["Decode"] = True
+        elif phase == "Execute":
+            pins["Execute"] = True
+        elif phase == "Commit":
+            pins["Commit"] = True
+        elif phase == "PCUpdate":
+            pins["PCUpdate"] = True
+        else:
+            raise ValueError(f"Bad phase: {phase}")
+
+        # Set the output pins
+        for k, v in pins.items():
+            self._outputs[self.Output_Pins[k]] = v
+
+
+    def _read_input_bus(self, bus_name: str) -> int:
+        target_pins = self.Input_Pins[bus_name]
+        vals = []
+        for p in target_pins:
+            vals.append(self._inputs[p])
+
+        value = bitarray.util.ba2int(bitarray.bitarray(vals, endian="little"))
+        return value
+
+    def A_bus(self) -> int:
+        return self._read_input_bus("A_bus")
+
+    def B_bus(self) -> int:
+        return self._read_input_bus("B_bus")
+
+    def C_bus_read(self) -> int:
+        return self._read_input_bus("C_bus")
+
+    
+    def _select_register(register_name: str, id: int):
+        assert isinstance(id, int)
+        assert id>=0 and id <8
+
+        converted = bitarray.util.int2ba(id, length=3, endian="little")
+        for i in range(3):
+            self._outputs[self.Output_pins[id][i]] = converted[i]
+            
+        
+
+    def R_A(self, id: int):
+        self._select_register("R_A", id)
+
+    def R_B(self, id: int):
+        self._select_register("R_B", id)
+
+    def R_C(self, id:int):
+        self._select_register("R_C", id)

--- a/pcbs/python-testing/register_file_connector_board.py
+++ b/pcbs/python-testing/register_file_connector_board.py
@@ -63,7 +63,6 @@ class RegisterFileConnectorBoard:
         for i in range(8):
             self._outputs[self.Output_Pins[bus_name][i]] = converted[i]
 
-
     def C_bus_write(self, value: int):
         self._set_output_bus(value, "C_bus")
 
@@ -76,7 +75,6 @@ class RegisterFileConnectorBoard:
             # C_bus
             self._tb.enable_output([False, True, True, True, True])
         self._outputs[self.Output_Pins["C_write_read"]] = value
-
 
     def Phase(self, phase: str):
         pins = dict(Commit=False, Execute=False, Decode=False, PCUpdate=False)
@@ -97,7 +95,6 @@ class RegisterFileConnectorBoard:
         for k, v in pins.items():
             self._outputs[self.Output_Pins[k]] = v
 
-
     def _read_input_bus(self, bus_name: str) -> int:
         target_pins = self.Input_Pins[bus_name]
         vals = []
@@ -116,16 +113,13 @@ class RegisterFileConnectorBoard:
     def C_bus_read(self) -> int:
         return self._read_input_bus("C_bus")
 
-    
     def _select_register(register_name: str, id: int):
         assert isinstance(id, int)
-        assert id>=0 and id <8
+        assert id >= 0 and id < 8
 
         converted = bitarray.util.int2ba(id, length=3, endian="little")
         for i in range(3):
             self._outputs[self.Output_pins[id][i]] = converted[i]
-            
-        
 
     def R_A(self, id: int):
         self._select_register("R_A", id)
@@ -133,5 +127,5 @@ class RegisterFileConnectorBoard:
     def R_B(self, id: int):
         self._select_register("R_B", id)
 
-    def R_C(self, id:int):
+    def R_C(self, id: int):
         self._select_register("R_C", id)

--- a/pcbs/python-testing/register_file_connector_board.py
+++ b/pcbs/python-testing/register_file_connector_board.py
@@ -69,11 +69,11 @@ class RegisterFileConnectorBoard:
     def C_write_read(self, value: bool):
         if value:
             # Going to write to C_bus, need to enable output
-            self._tb.enable_output([True, True, True, True, True])
+            self._tb.enable_outputs([True, True, True, True, True])
         else:
             # We're reading, so need to disable the output pins for
             # C_bus
-            self._tb.enable_output([False, True, True, True, True])
+            self._tb.enable_outputs([False, True, True, True, True])
         self._outputs[self.Output_Pins["C_write_read"]] = value
 
     def Phase(self, phase: str):
@@ -113,13 +113,14 @@ class RegisterFileConnectorBoard:
     def C_bus_read(self) -> int:
         return self._read_input_bus("C_bus")
 
-    def _select_register(register_name: str, id: int):
+    def _select_register(self, register_name: str, id: int):
         assert isinstance(id, int)
         assert id >= 0 and id < 8
 
         converted = bitarray.util.int2ba(id, length=3, endian="little")
         for i in range(3):
-            self._outputs[self.Output_pins[id][i]] = converted[i]
+            target_pin = self.Output_Pins[register_name][i]
+            self._outputs[target_pin] = converted[i]
 
     def R_A(self, id: int):
         self._select_register("R_A", id)

--- a/pcbs/python-testing/test_register_file.py
+++ b/pcbs/python-testing/test_register_file.py
@@ -44,14 +44,16 @@ class TestSmoke:
             assert rfcb.B_bus() == 0
             assert rfcb.C_bus_read() == 0
 
-        for reg in range(8):
-            rfcb.Phase("Decode")
-            rfcb.C_write_read(False)
-            rfcb.R_A(reg)
-            rfcb.R_B(reg)
-            rfcb.R_C(reg)
-            rfcb.send()
-            rfcb.recv()
-            assert rfcb.A_bus() == expected[reg]
-            assert rfcb.B_bus() == expected[reg]
-            assert rfcb.C_bus_read() == expected[reg]
+        output_phases = ["Decode", "Execute", "Commit", "PCUpdate"]
+        for phase in output_phases:
+            for reg in range(8):
+                rfcb.Phase(phase)
+                rfcb.C_write_read(False)
+                rfcb.R_A(reg)
+                rfcb.R_B(reg)
+                rfcb.R_C(reg)
+                rfcb.send()
+                rfcb.recv()
+                assert rfcb.A_bus() == expected[reg]
+                assert rfcb.B_bus() == expected[reg]
+                assert rfcb.C_bus_read() == expected[reg]

--- a/pcbs/python-testing/test_register_file.py
+++ b/pcbs/python-testing/test_register_file.py
@@ -1,0 +1,57 @@
+from typing import List
+
+import bitarray.util
+import pytest
+
+from register_file_connector_board import RegisterFileConnectorBoard
+
+# Have discovered a mistake: the board has the regisers update on
+# Execute, when it should be happening on Commit
+
+class TestSmoke:
+    def test_smoke(self):
+        rfcb = RegisterFileConnectorBoard()
+
+        expected = []
+        for reg in range(8):
+            rfcb.Phase("Other")
+            rfcb.R_A(reg)
+            rfcb.R_B(reg)
+            rfcb.R_C(reg)
+            rfcb.C_write_read(True)
+            nxt_val = 2**(1+reg) - 1
+            rfcb.C_bus_write(nxt_val)
+            expected.append(nxt_val)
+            rfcb.Phase("Decode")
+            rfcb.send()
+            rfcb.Phase("Execute")
+            rfcb.send()
+            rfcb.Phase("Commit")
+            rfcb.send()
+            rfcb.Phase("Other")
+            rfcb.send()
+
+        # Now do some reading
+        for reg in range(8):
+            rfcb.Phase("Other")
+            rfcb.C_write_read(False)
+            rfcb.R_A(reg)
+            rfcb.R_B(reg)
+            rfcb.R_C(reg)
+            rfcb.send()
+            rfcb.recv()
+            assert rfcb.A_bus() == 0
+            assert rfcb.B_bus() == 0
+            assert rfcb.C_bus_read() == 0
+
+        for reg in range(8):
+            rfcb.Phase("Decode")
+            rfcb.C_write_read(False)
+            rfcb.R_A(reg)
+            rfcb.R_B(reg)
+            rfcb.R_C(reg)
+            rfcb.send()
+            rfcb.recv()
+            assert rfcb.A_bus() == expected[reg]
+            assert rfcb.B_bus() == expected[reg]
+            assert rfcb.C_bus_read() == expected[reg]

--- a/pcbs/python-testing/test_register_file.py
+++ b/pcbs/python-testing/test_register_file.py
@@ -8,7 +8,8 @@ from register_file_connector_board import RegisterFileConnectorBoard
 # Have discovered a mistake: the board has the regisers update on
 # Execute, when it should be happening on Commit
 
-class TestSmoke:
+
+class TestRegisterFile:
     def test_smoke(self):
         rfcb = RegisterFileConnectorBoard()
 
@@ -19,11 +20,12 @@ class TestSmoke:
             rfcb.R_B(reg)
             rfcb.R_C(reg)
             rfcb.C_write_read(True)
-            nxt_val = 2**(1+reg) - 1
+            nxt_val = 2 ** (1 + reg) - 1
             rfcb.C_bus_write(nxt_val)
             expected.append(nxt_val)
             rfcb.Phase("Decode")
             rfcb.send()
+            # Bug on board, we write on Execute :-/
             rfcb.Phase("Execute")
             rfcb.send()
             rfcb.Phase("Commit")
@@ -57,3 +59,112 @@ class TestSmoke:
                 assert rfcb.A_bus() == expected[reg]
                 assert rfcb.B_bus() == expected[reg]
                 assert rfcb.C_bus_read() == expected[reg]
+
+        rfcb.Phase("Other")
+        rfcb.send()
+
+    @pytest.mark.parametrize("target_register", range(8))
+    @pytest.mark.parametrize(
+        "target_value", [0, 1, 2, 63, 64, 65, 93, 101, 127, 128, 129, 180, 254, 255]
+    )
+    def test_target_register(self, target_register: int, target_value: int):
+        rfcb = RegisterFileConnectorBoard()
+
+        expected = []
+        for reg in range(8):
+            rfcb.Phase("Other")
+            rfcb.R_C(reg)
+            rfcb.C_write_read(True)
+            if reg == target_register:
+                nxt_val = target_value
+            else:
+                nxt_val = 2 ** (1 + reg) - 1
+            rfcb.C_bus_write(nxt_val)
+            expected.append(nxt_val)
+            # Bug on board, we write on Execute :-/
+            rfcb.Phase("Execute")
+            rfcb.send()
+            rfcb.Phase("Other")
+            rfcb.send()
+
+        for r_a in range(8):
+            for r_b in range(8):
+                rfcb.Phase("Other")
+                rfcb.R_A(r_a)
+                rfcb.R_B(r_b)
+                rfcb.send()
+                rfcb.recv()
+                assert rfcb.A_bus() == 0
+                assert rfcb.B_bus() == 0
+
+        # It _should_ be Execute, not Commit, but for board bug
+        check_phases = ["Decode", "Commit", "PCUpdate"]
+        for phase in check_phases:
+            for r_a in range(8):
+                for r_b in range(8):
+                    rfcb.Phase(phase)
+                    rfcb.R_A(r_a)
+                    rfcb.R_B(r_b)
+                    rfcb.send()
+                    rfcb.recv()
+                    assert rfcb.A_bus() == expected[r_a]
+                    assert rfcb.B_bus() == expected[r_b]
+
+        rfcb.Phase("Other")
+        rfcb.send()
+
+    @pytest.mark.parametrize("target_register", range(8))
+    @pytest.mark.parametrize(
+        "target_value", [0, 1, 2, 63, 64, 65, 93, 101, 127, 128, 129, 180, 254, 255]
+    )
+    def test_target_register_all_read(self, target_register: int, target_value: int):
+        rfcb = RegisterFileConnectorBoard()
+
+        expected = []
+        for reg in range(8):
+            rfcb.Phase("Other")
+            rfcb.R_C(reg)
+            rfcb.C_write_read(True)
+            if reg == target_register:
+                nxt_val = target_value
+            else:
+                nxt_val = 2 ** (1 + reg) - 1
+            rfcb.C_bus_write(nxt_val)
+            expected.append(nxt_val)
+            # Bug on board, we write on Execute :-/
+            rfcb.Phase("Execute")
+            rfcb.send()
+            rfcb.Phase("Other")
+            rfcb.send()
+
+        for r_a in range(8):
+            for r_b in range(8):
+                for r_c in range(8):
+                    rfcb.Phase("Other")
+                    rfcb.C_write_read(False)
+                    rfcb.R_A(r_a)
+                    rfcb.R_B(r_b)
+                    rfcb.R_C(r_c)
+                    rfcb.send()
+                    rfcb.recv()
+                    assert rfcb.A_bus() == 0
+                    assert rfcb.B_bus() == 0
+                    assert rfcb.C_bus_read() == 0
+
+        check_phases = ["Decode", "Execute", "Commit", "PCUpdate"]
+        for phase in check_phases:
+            for r_a in range(8):
+                for r_b in range(8):
+                    for r_c in range(8):
+                        rfcb.Phase(phase)
+                        rfcb.R_A(r_a)
+                        rfcb.R_B(r_b)
+                        rfcb.R_C(r_c)
+                        rfcb.send()
+                        rfcb.recv()
+                        assert rfcb.A_bus() == expected[r_a]
+                        assert rfcb.B_bus() == expected[r_b]
+                        assert rfcb.C_bus_read() == expected[r_c]
+
+        rfcb.Phase("Other")
+        rfcb.send()


### PR DESCRIPTION
Create a test suite for the Register File. As noted in Issue #58 this has uncovered the fact that the register file is updating on 'Execute' when it should be updating on 'Commit' and the tests have to reflect this.